### PR TITLE
[FAB-17833] Remove SigningIdentity type from MSP type

### DIFF
--- a/configtx/capabilities_test.go
+++ b/configtx/capabilities_test.go
@@ -53,7 +53,7 @@ func TestOrdererCapabilities(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	baseOrdererConf := baseSoloOrderer(t)
+	baseOrdererConf, _ := baseSoloOrderer(t)
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
 	gt.Expect(err).NotTo(HaveOccurred())
 
@@ -83,7 +83,7 @@ func TestApplicationCapabilities(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	baseApplicationConf := baseApplication(t)
+	baseApplicationConf, _ := baseApplication(t)
 	applicationGroup, err := newApplicationGroup(baseApplicationConf)
 	gt.Expect(err).NotTo(HaveOccurred())
 
@@ -197,7 +197,7 @@ func TestAddOrdererCapability(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	baseOrdererConf := baseSoloOrderer(t)
+	baseOrdererConf, _ := baseSoloOrderer(t)
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
 	gt.Expect(err).NotTo(HaveOccurred())
 
@@ -212,7 +212,7 @@ func TestAddOrdererCapability(t *testing.T) {
 	c := New(config)
 
 	ordererOrgMSP := baseOrdererConf.Organizations[0].MSP
-	orgCertBase64, orgPKBase64, orgCRLBase64 := certPrivKeyCRLBase64(t, ordererOrgMSP)
+	orgCertBase64, orgCRLBase64 := certCRLBase64(t, ordererOrgMSP)
 
 	expectedConfigGroupJSON := fmt.Sprintf(`{
 	"groups": {
@@ -321,13 +321,7 @@ func TestAddOrdererCapability(t *testing.T) {
 							"root_certs": [
 								"%[1]s"
 							],
-							"signing_identity": {
-								"private_signer": {
-									"key_identifier": "SKI-1",
-									"key_material": "%[3]s"
-								},
-								"public_signer": "%[1]s"
-							},
+							"signing_identity": null,
 							"tls_intermediate_certs": [
 								"%[1]s"
 							],
@@ -434,7 +428,7 @@ func TestAddOrdererCapability(t *testing.T) {
 	},
 	"version": "0"
 }
-`, orgCertBase64, orgCRLBase64, orgPKBase64)
+`, orgCertBase64, orgCRLBase64)
 
 	capability := "V3_0"
 	err = c.AddOrdererCapability(capability)
@@ -477,7 +471,7 @@ func TestAddOrdererCapabilityFailures(t *testing.T) {
 
 			gt := NewGomegaWithT(t)
 
-			baseOrdererConf := baseSoloOrderer(t)
+			baseOrdererConf, _ := baseSoloOrderer(t)
 			ordererGroup, err := newOrdererGroup(baseOrdererConf)
 			gt.Expect(err).NotTo(HaveOccurred())
 			tt.ordererGroup(ordererGroup)
@@ -682,7 +676,7 @@ func TestAddApplicationCapability(t *testing.T) {
 			t.Parallel()
 			gt := NewGomegaWithT(t)
 
-			baseApp := baseApplication(t)
+			baseApp, _ := baseApplication(t)
 			appGroup, err := newApplicationGroup(baseApp)
 			gt.Expect(err).NotTo(HaveOccurred())
 
@@ -746,7 +740,7 @@ func TestAddApplicationCapabilityFailures(t *testing.T) {
 
 			gt := NewGomegaWithT(t)
 
-			baseApp := baseApplication(t)
+			baseApp, _ := baseApplication(t)
 			appGroup, err := newApplicationGroup(baseApp)
 			gt.Expect(err).NotTo(HaveOccurred())
 			tt.applicationGroup(appGroup)
@@ -873,7 +867,7 @@ func TestRemoveOrdererCapability(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	baseOrdererConf := baseSoloOrderer(t)
+	baseOrdererConf, _ := baseSoloOrderer(t)
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
 	gt.Expect(err).NotTo(HaveOccurred())
 
@@ -888,7 +882,7 @@ func TestRemoveOrdererCapability(t *testing.T) {
 	c := New(config)
 
 	ordererOrgMSP := baseOrdererConf.Organizations[0].MSP
-	orgCertBase64, orgPKBase64, orgCRLBase64 := certPrivKeyCRLBase64(t, ordererOrgMSP)
+	orgCertBase64, orgCRLBase64 := certCRLBase64(t, ordererOrgMSP)
 
 	expectedConfigGroupJSON := fmt.Sprintf(`{
 	"groups": {
@@ -997,13 +991,7 @@ func TestRemoveOrdererCapability(t *testing.T) {
 							"root_certs": [
 								"%[1]s"
 							],
-							"signing_identity": {
-								"private_signer": {
-									"key_identifier": "SKI-1",
-									"key_material": "%[3]s"
-								},
-								"public_signer": "%[1]s"
-							},
+							"signing_identity": null,
 							"tls_intermediate_certs": [
 								"%[1]s"
 							],
@@ -1107,7 +1095,7 @@ func TestRemoveOrdererCapability(t *testing.T) {
 	},
 	"version": "0"
 }
-`, orgCertBase64, orgCRLBase64, orgPKBase64)
+`, orgCertBase64, orgCRLBase64)
 
 	capability := "V1_3"
 	err = c.RemoveOrdererCapability(capability)
@@ -1157,7 +1145,7 @@ func TestRemoveOrdererCapabilityFailures(t *testing.T) {
 
 			gt := NewGomegaWithT(t)
 
-			baseOrdererConf := baseSoloOrderer(t)
+			baseOrdererConf, _ := baseSoloOrderer(t)
 			ordererGroup, err := newOrdererGroup(baseOrdererConf)
 			gt.Expect(err).NotTo(HaveOccurred())
 			tt.ordererGroup(ordererGroup)
@@ -1183,7 +1171,7 @@ func TestRemoveApplicationCapability(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	baseApp := baseApplication(t)
+	baseApp, _ := baseApplication(t)
 	appGroup, err := newApplicationGroup(baseApp)
 	gt.Expect(err).NotTo(HaveOccurred())
 
@@ -1321,7 +1309,7 @@ func TestRemoveApplicationCapabilityFailures(t *testing.T) {
 
 			gt := NewGomegaWithT(t)
 
-			baseApp := baseApplication(t)
+			baseApp, _ := baseApplication(t)
 			appGroup, err := newApplicationGroup(baseApp)
 			gt.Expect(err).NotTo(HaveOccurred())
 			tt.applicationGroup(appGroup)

--- a/configtx/config_test.go
+++ b/configtx/config_test.go
@@ -8,6 +8,7 @@ package configtx
 
 import (
 	"bytes"
+	"crypto/ecdsa"
 	"errors"
 	"fmt"
 	"testing"
@@ -401,16 +402,16 @@ func TestNewSystemChannelGenesisBlock(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	profile := baseSystemChannelProfile(t)
+	profile, _, _ := baseSystemChannelProfile(t)
 
 	block, err := NewSystemChannelGenesisBlock(profile, "testsystemchannel")
 	gt.Expect(err).ToNot(HaveOccurred())
 	gt.Expect(block).ToNot(BeNil())
 	gt.Expect(block.Header.Number).To(Equal(uint64(0)))
 
-	org1CertBase64, org1PkBase64, org1CrlBase64 := certPrivKeyCRLBase64(t, profile.Consortiums[0].Organizations[0].MSP)
-	org2CertBase64, org2PkBase64, org2CrlBase64 := certPrivKeyCRLBase64(t, profile.Consortiums[0].Organizations[1].MSP)
-	ordererOrgCertBase64, ordererOrgPkBase64, ordererOrgCrlBase64 := certPrivKeyCRLBase64(t, profile.Orderer.Organizations[0].MSP)
+	org1CertBase64, org1CrlBase64 := certCRLBase64(t, profile.Consortiums[0].Organizations[0].MSP)
+	org2CertBase64, org2CrlBase64 := certCRLBase64(t, profile.Consortiums[0].Organizations[1].MSP)
+	ordererOrgCertBase64, ordererOrgCrlBase64 := certCRLBase64(t, profile.Orderer.Organizations[0].MSP)
 
 	expectBlockJSON := fmt.Sprintf(`
 {
@@ -522,13 +523,7 @@ func TestNewSystemChannelGenesisBlock(t *testing.T) {
 																		"root_certs": [
 																			"%[1]s"
 																		],
-																		"signing_identity": {
-																			"private_signer": {
-																				"key_identifier": "SKI-1",
-																				"key_material": "%[3]s"
-																			},
-																			"public_signer": "%[1]s"
-																		},
+																		"signing_identity": null,
 																		"tls_intermediate_certs": [
 																			"%[1]s"
 																		],
@@ -598,7 +593,7 @@ func TestNewSystemChannelGenesisBlock(t *testing.T) {
 																"value": {
 																	"config": {
 																		"admins": [
-																			"%[4]s"
+																			"%[3]s"
 																		],
 																		"crypto_config": {
 																			"identity_identifier_hash_function": "SHA256",
@@ -606,51 +601,45 @@ func TestNewSystemChannelGenesisBlock(t *testing.T) {
 																		},
 																		"fabric_node_ous": {
 																			"admin_ou_identifier": {
-																				"certificate": "%[4]s",
+																				"certificate": "%[3]s",
 																				"organizational_unit_identifier": "OUID"
 																			},
 																			"client_ou_identifier": {
-																				"certificate": "%[4]s",
+																				"certificate": "%[3]s",
 																				"organizational_unit_identifier": "OUID"
 																			},
 																			"enable": false,
 																			"orderer_ou_identifier": {
-																				"certificate": "%[4]s",
+																				"certificate": "%[3]s",
 																				"organizational_unit_identifier": "OUID"
 																			},
 																			"peer_ou_identifier": {
-																				"certificate": "%[4]s",
+																				"certificate": "%[3]s",
 																				"organizational_unit_identifier": "OUID"
 																			}
 																		},
 																		"intermediate_certs": [
-																			"%[4]s"
+																			"%[3]s"
 																		],
 																		"name": "MSPID",
 																		"organizational_unit_identifiers": [
 																			{
-																				"certificate": "%[4]s",
+																				"certificate": "%[3]s",
 																				"organizational_unit_identifier": "OUID"
 																			}
 																		],
 																		"revocation_list": [
-																			"%[5]s"
+																			"%[4]s"
 																		],
 																		"root_certs": [
-																			"%[4]s"
+																			"%[3]s"
 																		],
-																		"signing_identity": {
-																			"private_signer": {
-																				"key_identifier": "SKI-1",
-																				"key_material": "%[6]s"
-																			},
-																			"public_signer": "%[4]s"
-																		},
+																		"signing_identity": null,
 																		"tls_intermediate_certs": [
-																			"%[4]s"
+																			"%[3]s"
 																		],
 																		"tls_root_certs": [
-																			"%[4]s"
+																			"%[3]s"
 																		]
 																	},
 																	"type": 0
@@ -768,7 +757,7 @@ func TestNewSystemChannelGenesisBlock(t *testing.T) {
 														"value": {
 															"config": {
 																"admins": [
-																	"%[7]s"
+																	"%[5]s"
 																],
 																"crypto_config": {
 																	"identity_identifier_hash_function": "SHA256",
@@ -776,51 +765,45 @@ func TestNewSystemChannelGenesisBlock(t *testing.T) {
 																},
 																"fabric_node_ous": {
 																	"admin_ou_identifier": {
-																		"certificate": "%[7]s",
+																		"certificate": "%[5]s",
 																		"organizational_unit_identifier": "OUID"
 																	},
 																	"client_ou_identifier": {
-																		"certificate": "%[7]s",
+																		"certificate": "%[5]s",
 																		"organizational_unit_identifier": "OUID"
 																	},
 																	"enable": false,
 																	"orderer_ou_identifier": {
-																		"certificate": "%[7]s",
+																		"certificate": "%[5]s",
 																		"organizational_unit_identifier": "OUID"
 																	},
 																	"peer_ou_identifier": {
-																		"certificate": "%[7]s",
+																		"certificate": "%[5]s",
 																		"organizational_unit_identifier": "OUID"
 																	}
 																},
 																"intermediate_certs": [
-																	"%[7]s"
+																	"%[5]s"
 																],
 																"name": "MSPID",
 																"organizational_unit_identifiers": [
 																	{
-																		"certificate": "%[7]s",
+																		"certificate": "%[5]s",
 																		"organizational_unit_identifier": "OUID"
 																	}
 																],
 																"revocation_list": [
-																	"%[8]s"
+																	"%[6]s"
 																],
 																"root_certs": [
-																	"%[7]s"
+																	"%[5]s"
 																],
-																"signing_identity": {
-																	"private_signer": {
-																		"key_identifier": "SKI-1",
-																		"key_material": "%[9]s"
-																	},
-																	"public_signer": "%[7]s"
-																},
+																"signing_identity": null,
 																"tls_intermediate_certs": [
-																	"%[7]s"
+																	"%[5]s"
 																],
 																"tls_root_certs": [
-																	"%[7]s"
+																	"%[5]s"
 																]
 															},
 															"type": 0
@@ -1020,7 +1003,7 @@ func TestNewSystemChannelGenesisBlock(t *testing.T) {
 		]
 	}
 }
-`, org1CertBase64, org1CrlBase64, org1PkBase64, org2CertBase64, org2CrlBase64, org2PkBase64, ordererOrgCertBase64, ordererOrgCrlBase64, ordererOrgPkBase64)
+`, org1CertBase64, org1CrlBase64, org2CertBase64, org2CrlBase64, ordererOrgCertBase64, ordererOrgCrlBase64)
 
 	expectedBlock := &cb.Block{}
 	err = protolator.DeepUnmarshalJSON(bytes.NewBufferString(expectBlockJSON), expectedBlock)
@@ -1077,7 +1060,7 @@ func TestNewSystemChannelGenesisBlockFailure(t *testing.T) {
 		{
 			testName: "When channel ID is not specified in config",
 			profileMod: func() Channel {
-				profile := baseSystemChannelProfile(t)
+				profile, _, _ := baseSystemChannelProfile(t)
 				return profile
 			},
 			channelID: "",
@@ -1086,7 +1069,7 @@ func TestNewSystemChannelGenesisBlockFailure(t *testing.T) {
 		{
 			testName: "When creating the default system config template with empty orderer endpoints",
 			profileMod: func() Channel {
-				profile := baseSystemChannelProfile(t)
+				profile, _, _ := baseSystemChannelProfile(t)
 				profile.Orderer.Addresses = []Address{}
 				return profile
 			},
@@ -1096,7 +1079,7 @@ func TestNewSystemChannelGenesisBlockFailure(t *testing.T) {
 		{
 			testName: "When creating the default config template with empty capabilities",
 			profileMod: func() Channel {
-				profile := baseSystemChannelProfile(t)
+				profile, _, _ := baseSystemChannelProfile(t)
 				profile.Capabilities = []string{}
 				return profile
 			},
@@ -1106,7 +1089,7 @@ func TestNewSystemChannelGenesisBlockFailure(t *testing.T) {
 		{
 			testName: "When creating the default config template without consortiums",
 			profileMod: func() Channel {
-				profile := baseSystemChannelProfile(t)
+				profile, _, _ := baseSystemChannelProfile(t)
 				profile.Orderer = Orderer{}
 				return profile
 			},
@@ -1233,9 +1216,9 @@ func TestComputeUpdateFailures(t *testing.T) {
 func TestChannelConfiguration(t *testing.T) {
 	t.Parallel()
 
-	baseApplication := baseApplication(t)
-	baseConsortiums := baseConsortiums(t)
-	baseOrderer := baseSoloOrderer(t)
+	baseApplication, _ := baseApplication(t)
+	baseConsortiums, _ := baseConsortiums(t)
+	baseOrderer, _ := baseSoloOrderer(t)
 	policies := standardPolicies()
 
 	tests := []struct {
@@ -1319,20 +1302,23 @@ func TestChannelConfiguration(t *testing.T) {
 }
 
 func baseProfile(t *testing.T) Channel {
+	application, _ := baseApplication(t)
 	return Channel{
 		Consortium:   "SampleConsortium",
-		Application:  baseApplication(t),
+		Application:  application,
 		Capabilities: []string{"V2_0"},
 	}
 }
 
-func baseSystemChannelProfile(t *testing.T) Channel {
+func baseSystemChannelProfile(t *testing.T) (Channel, []*ecdsa.PrivateKey, *ecdsa.PrivateKey) {
+	consortiums, consortiumsPrivKey := baseConsortiums(t)
+	orderer, ordererPrivKeys := baseSoloOrderer(t)
 	return Channel{
-		Consortiums:  baseConsortiums(t),
-		Orderer:      baseSoloOrderer(t),
+		Consortiums:  consortiums,
+		Orderer:      orderer,
 		Capabilities: []string{"V2_0"},
 		Policies:     standardPolicies(),
-	}
+	}, consortiumsPrivKey, ordererPrivKeys[0]
 }
 
 func standardPolicies() map[string]Policy {
@@ -1387,24 +1373,24 @@ func ordererStandardPolicies() map[string]Policy {
 
 // baseApplicationChannelGroup creates a channel config group
 // that only contains an Application group.
-func baseApplicationChannelGroup(t *testing.T) (*cb.ConfigGroup, error) {
+func baseApplicationChannelGroup(t *testing.T) (*cb.ConfigGroup, []*ecdsa.PrivateKey, error) {
 	channelGroup := newConfigGroup()
 
-	application := baseApplication(t)
+	application, privKeys := baseApplication(t)
 	applicationGroup, err := newApplicationGroup(application)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for _, org := range application.Organizations {
 		orgGroup, err := newOrgConfigGroup(org)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		applicationGroup.Groups[org.Name] = orgGroup
 	}
 
 	channelGroup.Groups[ApplicationGroupKey] = applicationGroup
 
-	return channelGroup, nil
+	return channelGroup, privKeys, nil
 }

--- a/configtx/example_test.go
+++ b/configtx/example_test.go
@@ -991,11 +991,6 @@ func baseMSP(t *testing.T) configtx.MSP {
 	cert, err := x509.ParseCertificate(certBlock.Bytes)
 	gt.Expect(err).NotTo(HaveOccurred())
 
-	privKeyBlock, _ := pem.Decode([]byte(dummyPrivateKey))
-	gt.Expect(privKeyBlock).NotTo(BeNil())
-	privKey, err := x509.ParsePKCS8PrivateKey(privKeyBlock.Bytes)
-	gt.Expect(err).NotTo(HaveOccurred())
-
 	crlBlock, _ := pem.Decode([]byte(dummyCRL))
 	gt.Expect(crlBlock).NotTo(BeNil())
 	crl, err := x509.ParseCRL(crlBlock.Bytes)
@@ -1007,13 +1002,6 @@ func baseMSP(t *testing.T) configtx.MSP {
 		IntermediateCerts: []*x509.Certificate{cert},
 		Admins:            []*x509.Certificate{cert},
 		RevocationList:    []*pkix.CertificateList{crl},
-		SigningIdentity: membership.SigningIdentityInfo{
-			PublicSigner: cert,
-			PrivateSigner: membership.KeyInfo{
-				KeyIdentifier: "SKI-1",
-				KeyMaterial:   privKey.(*ecdsa.PrivateKey),
-			},
-		},
 		OrganizationalUnitIdentifiers: []membership.OUIdentifier{
 			{
 				Certificate:                  cert,

--- a/configtx/organization_test.go
+++ b/configtx/organization_test.go
@@ -121,7 +121,7 @@ func TestOrdererOrg(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channel := baseSystemChannelProfile(t)
+	channel, _, _ := baseSystemChannelProfile(t)
 	channelGroup, err := newSystemChannelGroup(channel)
 	gt.Expect(err).NotTo(HaveOccurred())
 
@@ -172,7 +172,7 @@ func TestRemoveOrdererOrg(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channel := baseSystemChannelProfile(t)
+	channel, _, _ := baseSystemChannelProfile(t)
 	channelGroup, err := newSystemChannelGroup(channel)
 	gt.Expect(err).NotTo(HaveOccurred())
 
@@ -190,7 +190,7 @@ func TestConsortiumOrg(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channel := baseSystemChannelProfile(t)
+	channel, _, _ := baseSystemChannelProfile(t)
 	channelGroup, err := newSystemChannelGroup(channel)
 	gt.Expect(err).NotTo(HaveOccurred())
 
@@ -250,7 +250,7 @@ func TestRemoveConsortiumOrg(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channel := baseSystemChannelProfile(t)
+	channel, _, _ := baseSystemChannelProfile(t)
 	channelGroup, err := newSystemChannelGroup(channel)
 	gt.Expect(err).NotTo(HaveOccurred())
 
@@ -271,11 +271,12 @@ func TestNewOrgConfigGroup(t *testing.T) {
 		t.Parallel()
 		gt := NewGomegaWithT(t)
 
-		org := baseSystemChannelProfile(t).Orderer.Organizations[0]
+		baseSystemChannelProfile, _, _ := baseSystemChannelProfile(t)
+		org := baseSystemChannelProfile.Orderer.Organizations[0]
 		configGroup, err := newOrgConfigGroup(org)
 		gt.Expect(err).NotTo(HaveOccurred())
 
-		certBase64, pkBase64, crlBase64 := certPrivKeyCRLBase64(t, org.MSP)
+		certBase64, crlBase64 := certCRLBase64(t, org.MSP)
 
 		// The organization is from network.BasicSolo Profile
 		// configtxgen -printOrg Org1
@@ -385,13 +386,7 @@ func TestNewOrgConfigGroup(t *testing.T) {
 					"root_certs": [
 						"%[1]s"
 					],
-					"signing_identity": {
-						"private_signer": {
-							"key_identifier": "SKI-1",
-							"key_material": "%[3]s"
-						},
-						"public_signer": "%[1]s"
-					},
+					"signing_identity": null,
 					"tls_intermediate_certs": [
 						"%[1]s"
 					],
@@ -406,7 +401,7 @@ func TestNewOrgConfigGroup(t *testing.T) {
 	},
 	"version": "0"
 }
-`, certBase64, crlBase64, pkBase64)
+`, certBase64, crlBase64)
 
 		buf := bytes.Buffer{}
 		err = protolator.DeepMarshalJSON(&buf, &ordererext.DynamicOrdererOrgGroup{ConfigGroup: configGroup})
@@ -421,7 +416,8 @@ func TestNewOrgConfigGroupFailure(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	baseOrg := baseSystemChannelProfile(t).Orderer.Organizations[0]
+	baseSystemChannelProfile, _, _ := baseSystemChannelProfile(t)
+	baseOrg := baseSystemChannelProfile.Orderer.Organizations[0]
 	baseOrg.Policies = nil
 
 	configGroup, err := newOrgConfigGroup(baseOrg)
@@ -430,10 +426,11 @@ func TestNewOrgConfigGroupFailure(t *testing.T) {
 }
 
 func baseApplicationOrg(t *testing.T) Organization {
+	msp, _ := baseMSP(t)
 	return Organization{
 		Name:     "Org1",
 		Policies: standardPolicies(),
-		MSP:      baseMSP(t),
+		MSP:      msp,
 		AnchorPeers: []Address{
 			{Host: "host3", Port: 123},
 		},

--- a/configtx/policies_test.go
+++ b/configtx/policies_test.go
@@ -56,7 +56,7 @@ func TestRemoveApplicationOrgPolicy(t *testing.T) {
 	channelGroup := newConfigGroup()
 	applicationGroup := newConfigGroup()
 
-	application := baseApplication(t)
+	application, _ := baseApplication(t)
 
 	for _, org := range application.Organizations {
 		org.Policies = applicationOrgStandardPolicies()
@@ -95,7 +95,7 @@ func TestRemoveApplicationOrgPolicyFailures(t *testing.T) {
 	channelGroup := newConfigGroup()
 	applicationGroup := newConfigGroup()
 
-	application := baseApplication(t)
+	application, _ := baseApplication(t)
 	for _, org := range application.Organizations {
 		org.Policies = applicationOrgStandardPolicies()
 		orgGroup, err := newOrgConfigGroup(org)
@@ -126,7 +126,7 @@ func TestSetApplicationOrgPolicy(t *testing.T) {
 	channelGroup := newConfigGroup()
 	applicationGroup := newConfigGroup()
 
-	application := baseApplication(t)
+	application, _ := baseApplication(t)
 
 	for _, org := range application.Organizations {
 		org.Policies = applicationOrgStandardPolicies()
@@ -162,7 +162,7 @@ func TestSetApplicationOrgPolicyFailures(t *testing.T) {
 	channelGroup := newConfigGroup()
 	applicationGroup := newConfigGroup()
 
-	application := baseApplication(t)
+	application, _ := baseApplication(t)
 	for _, org := range application.Organizations {
 		org.Policies = applicationOrgStandardPolicies()
 
@@ -187,7 +187,7 @@ func TestSetApplicationPolicy(t *testing.T) {
 	gt := NewGomegaWithT(t)
 
 	channelGroup := newConfigGroup()
-	application := baseApplication(t)
+	application, _ := baseApplication(t)
 
 	applicationGroup, err := newApplicationGroup(application)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -231,7 +231,7 @@ func TestSetApplicationPolicyFailures(t *testing.T) {
 	gt := NewGomegaWithT(t)
 
 	channelGroup := newConfigGroup()
-	application := baseApplication(t)
+	application, _ := baseApplication(t)
 
 	applicationGroup, err := newApplicationGroup(application)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -255,7 +255,7 @@ func TestRemoveApplicationPolicy(t *testing.T) {
 	gt := NewGomegaWithT(t)
 
 	channelGroup := newConfigGroup()
-	application := baseApplication(t)
+	application, _ := baseApplication(t)
 
 	applicationGroup, err := newApplicationGroup(application)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -296,7 +296,7 @@ func TestRemoveApplicationPolicyFailures(t *testing.T) {
 	gt := NewGomegaWithT(t)
 
 	channelGroup := newConfigGroup()
-	application := baseApplication(t)
+	application, _ := baseApplication(t)
 
 	applicationGroup, err := newApplicationGroup(application)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -323,7 +323,7 @@ func TestSetConsortiumOrgPolicy(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	consortiums := baseConsortiums(t)
+	consortiums, _ := baseConsortiums(t)
 
 	consortiumsGroup, err := newConsortiumsGroup(consortiums)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -375,7 +375,7 @@ func TestSetConsortiumOrgPolicyFailures(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	consortiums := baseConsortiums(t)
+	consortiums, _ := baseConsortiums(t)
 
 	consortiumsGroup, err := newConsortiumsGroup(consortiums)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -415,7 +415,7 @@ func TestRemoveConsortiumOrgPolicy(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	consortiums := baseConsortiums(t)
+	consortiums, _ := baseConsortiums(t)
 
 	consortiums[0].Organizations[0].Policies["TestPolicy"] = Policy{Type: ImplicitMetaPolicyType, Rule: "MAJORITY Endorsement"}
 
@@ -464,7 +464,7 @@ func TestSetOrdererPolicy(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	baseOrdererConf := baseSoloOrderer(t)
+	baseOrdererConf, _ := baseSoloOrderer(t)
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -516,7 +516,7 @@ func TestSetOrdererPolicyFailures(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	baseOrdererConf := baseSoloOrderer(t)
+	baseOrdererConf, _ := baseSoloOrderer(t)
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -540,7 +540,7 @@ func TestRemoveOrdererPolicy(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	baseOrdererConf := baseSoloOrderer(t)
+	baseOrdererConf, _ := baseSoloOrderer(t)
 	baseOrdererConf.Policies["TestPolicy"] = baseOrdererConf.Policies[AdminsPolicyKey]
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
@@ -589,7 +589,7 @@ func TestRemoveOrdererPolicyFailures(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	baseOrdererConf := baseSoloOrderer(t)
+	baseOrdererConf, _ := baseSoloOrderer(t)
 	baseOrdererConf.Policies["TestPolicy"] = baseOrdererConf.Policies[AdminsPolicyKey]
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
@@ -652,7 +652,7 @@ func TestSetOrdererOrgPolicy(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	baseOrdererConf := baseSoloOrderer(t)
+	baseOrdererConf, _ := baseSoloOrderer(t)
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -704,7 +704,7 @@ func TestSetOrdererOrgPolicyFailures(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	baseOrdererConf := baseSoloOrderer(t)
+	baseOrdererConf, _ := baseSoloOrderer(t)
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -728,7 +728,7 @@ func TestRemoveOrdererOrgPolicy(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	baseOrdererConf := baseSoloOrderer(t)
+	baseOrdererConf, _ := baseSoloOrderer(t)
 	baseOrdererConf.Organizations[0].Policies["TestPolicy"] = baseOrdererConf.Organizations[0].Policies[AdminsPolicyKey]
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
@@ -777,7 +777,7 @@ func TestRemoveOrdererOrgPolicyFailures(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	baseOrdererConf := baseSoloOrderer(t)
+	baseOrdererConf, _ := baseSoloOrderer(t)
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -801,7 +801,7 @@ func TestSetConsortiumChannelCreationPolicy(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	consortiums := baseConsortiums(t)
+	consortiums, _ := baseConsortiums(t)
 
 	consortiumsGroup, err := newConsortiumsGroup(consortiums)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -838,7 +838,7 @@ func TestSetConsortiumChannelCreationPolicyFailures(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	consortiums := baseConsortiums(t)
+	consortiums, _ := baseConsortiums(t)
 
 	consortiumsGroup, err := newConsortiumsGroup(consortiums)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -881,7 +881,7 @@ func TestSetChannelPolicy(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channel, err := baseApplicationChannelGroup(t)
+	channel, _, err := baseApplicationChannelGroup(t)
 	gt.Expect(err).NotTo(HaveOccurred())
 
 	config := &cb.Config{
@@ -909,7 +909,7 @@ func TestRemoveChannelPolicy(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channel, err := baseApplicationChannelGroup(t)
+	channel, _, err := baseApplicationChannelGroup(t)
 	gt.Expect(err).NotTo(HaveOccurred())
 
 	config := &cb.Config{
@@ -947,7 +947,7 @@ func TestRemoveChannelPolicyFailures(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channel, err := baseApplicationChannelGroup(t)
+	channel, _, err := baseApplicationChannelGroup(t)
 	gt.Expect(err).NotTo(HaveOccurred())
 
 	config := &cb.Config{
@@ -972,7 +972,7 @@ func TestConsortiumOrgPolicies(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	consortiums := baseConsortiums(t)
+	consortiums, _ := baseConsortiums(t)
 
 	consortiumsGroup, err := newConsortiumsGroup(consortiums)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -1016,7 +1016,7 @@ func TestConsortiumOrgPoliciesFailures(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	consortiums := baseConsortiums(t)
+	consortiums, _ := baseConsortiums(t)
 
 	consortiumsGroup, err := newConsortiumsGroup(consortiums)
 	gt.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Remove SigningIdentity from MSP type because the SigningIdentity is not supposed to be updatable during channel config transactions

#### Related issues
[FAB-17833](https://jira.hyperledger.org/browse/FAB-17833)