### PR TITLE
[FAB-17836] Add newOrdererOrgConfigGroup and newApplicationOrgConfigGroup

### DIFF
--- a/configtx/application.go
+++ b/configtx/application.go
@@ -244,7 +244,7 @@ func (c *ConfigTx) AnchorPeers(orgName string) ([]Address, error) {
 func (c *ConfigTx) SetApplicationOrg(org Organization) error {
 	appGroup := c.updated.ChannelGroup.Groups[ApplicationGroupKey]
 
-	orgGroup, err := newOrgConfigGroup(org)
+	orgGroup, err := newApplicationOrgConfigGroup(org)
 	if err != nil {
 		return fmt.Errorf("failed to create application org %s: %v", org.Name, err)
 	}

--- a/configtx/orderer.go
+++ b/configtx/orderer.go
@@ -189,7 +189,7 @@ func (c *ConfigTx) OrdererConfiguration() (Orderer, error) {
 func (c *ConfigTx) SetOrdererOrg(org Organization) error {
 	ordererGroup := c.updated.ChannelGroup.Groups[OrdererGroupKey]
 
-	orgGroup, err := newOrgConfigGroup(org)
+	orgGroup, err := newOrdererOrgConfigGroup(org)
 	if err != nil {
 		return fmt.Errorf("failed to create orderer org '%s': %v", org.Name, err)
 	}
@@ -286,7 +286,7 @@ func newOrdererGroup(orderer Orderer) (*cb.ConfigGroup, error) {
 
 	// add orderer groups
 	for _, org := range orderer.Organizations {
-		ordererGroup.Groups[org.Name], err = newOrgConfigGroup(org)
+		ordererGroup.Groups[org.Name], err = newOrdererOrgConfigGroup(org)
 		if err != nil {
 			return nil, fmt.Errorf("org group '%s': %v", org.Name, err)
 		}

--- a/configtx/organization.go
+++ b/configtx/organization.go
@@ -135,12 +135,30 @@ func newOrgConfigGroup(org Organization) (*cb.ConfigGroup, error) {
 		return nil, err
 	}
 
+	return orgGroup, nil
+}
+
+func newOrdererOrgConfigGroup(org Organization) (*cb.ConfigGroup, error) {
+	orgGroup, err := newOrgConfigGroup(org)
+	if err != nil {
+		return nil, err
+	}
+
 	// OrdererEndpoints are orderer org specific and are only added when specified for orderer orgs
 	if len(org.OrdererEndpoints) > 0 {
 		err := setValue(orgGroup, endpointsValue(org.OrdererEndpoints), AdminsPolicyKey)
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	return orgGroup, nil
+}
+
+func newApplicationOrgConfigGroup(org Organization) (*cb.ConfigGroup, error) {
+	orgGroup, err := newOrgConfigGroup(org)
+	if err != nil {
+		return nil, err
 	}
 
 	// AnchorPeers are application org specific and are only added when specified for application orgs

--- a/configtx/organization_test.go
+++ b/configtx/organization_test.go
@@ -22,6 +22,7 @@ func TestOrganization(t *testing.T) {
 	gt := NewGomegaWithT(t)
 
 	expectedOrg := baseApplicationOrg(t)
+	expectedOrg.AnchorPeers = nil
 	orgGroup, err := newOrgConfigGroup(expectedOrg)
 	gt.Expect(err).NotTo(HaveOccurred())
 
@@ -43,7 +44,7 @@ func TestApplicationOrg(t *testing.T) {
 	}
 	channelGroup, err := newChannelGroup(channel)
 	gt.Expect(err).NotTo(HaveOccurred())
-	orgGroup, err := newOrgConfigGroup(channel.Application.Organizations[0])
+	orgGroup, err := newApplicationOrgConfigGroup(channel.Application.Organizations[0])
 	gt.Expect(err).NotTo(HaveOccurred())
 	channelGroup.Groups[ApplicationGroupKey].Groups["Org1"] = orgGroup
 
@@ -273,7 +274,7 @@ func TestNewOrgConfigGroup(t *testing.T) {
 
 		baseSystemChannelProfile, _, _ := baseSystemChannelProfile(t)
 		org := baseSystemChannelProfile.Orderer.Organizations[0]
-		configGroup, err := newOrgConfigGroup(org)
+		configGroup, err := newOrdererOrgConfigGroup(org)
 		gt.Expect(err).NotTo(HaveOccurred())
 
 		certBase64, crlBase64 := certCRLBase64(t, org.MSP)


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

- anchor peers are added to only application orgs
- endpoints are added to only orderer orgs
- anchor peers and endpoints are not added to consortium orgs

#### Related issues
[FAB-17836](https://jira.hyperledger.org/browse/FAB-17836)
