### PR TITLE
when FabricNodeOUs proto should be nil when unset

### DIFF
--- a/configtx/msp.go
+++ b/configtx/msp.go
@@ -428,7 +428,7 @@ func (m *MSP) toProto() (*mb.FabricMSPConfig, error) {
 
 	ouIdentifiers := buildOUIdentifiers(m.OrganizationalUnitIdentifiers)
 
-	fabricNodeOUs := &mb.FabricNodeOUs{}
+	var fabricNodeOUs *mb.FabricNodeOUs
 	if m.NodeOUs != (membership.NodeOUs{}) {
 		fabricNodeOUs = &mb.FabricNodeOUs{
 			Enable: m.NodeOUs.Enable,

--- a/configtx/msp_test.go
+++ b/configtx/msp_test.go
@@ -419,7 +419,7 @@ func TestMSPToProtoNoNodeOUs(t *testing.T) {
 		"identity_identifier_hash_function": "SHA256",
 		"signature_hash_family": "SHA3"
 	},
-	"fabric_node_ous": {},
+	"fabric_node_ous": null,
 	"intermediate_certs": [
 		"%[1]s"
 	],


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Declare FabricNodeOUs instead of initializing to ensure the proto value is nil 