### PR TITLE
Envelope and signing improvements

### DIFF
--- a/configtx/config.go
+++ b/configtx/config.go
@@ -109,6 +109,26 @@ func (c *ConfigTx) ComputeUpdate(channelID string) (*cb.ConfigUpdate, error) {
 	return updt, nil
 }
 
+// NewEnvelope creates an envelope with the provided config update and config signatures.
+func NewEnvelope(c *cb.ConfigUpdate, signatures ...*cb.ConfigSignature) (*cb.Envelope, error) {
+	cBytes, err := proto.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling config update: %v", err)
+	}
+
+	configUpdateEnvelope := &cb.ConfigUpdateEnvelope{
+		ConfigUpdate: cBytes,
+		Signatures:   signatures,
+	}
+
+	envelope, err := newEnvelope(cb.HeaderType_CONFIG_UPDATE, c.ChannelId, configUpdateEnvelope)
+	if err != nil {
+		return nil, err
+	}
+
+	return envelope, nil
+}
+
 // NewCreateChannelTx creates a create channel tx using the provided application channel
 // configuration and returns an unsigned envelope for an application channel creation transaction.
 func NewCreateChannelTx(channelConfig Channel, channelID string) (*cb.Envelope, error) {

--- a/configtx/config.go
+++ b/configtx/config.go
@@ -129,9 +129,9 @@ func NewEnvelope(c *cb.ConfigUpdate, signatures ...*cb.ConfigSignature) (*cb.Env
 	return envelope, nil
 }
 
-// NewCreateChannelTx creates a create channel tx using the provided application channel
-// configuration and returns an unsigned envelope for an application channel creation transaction.
-func NewCreateChannelTx(channelConfig Channel, channelID string) (*cb.Envelope, error) {
+// NewCreateChannelTx creates a create channel config update transaction using the
+// provided application channel configuration.
+func NewCreateChannelTx(channelConfig Channel, channelID string) (*cb.ConfigUpdate, error) {
 	var err error
 
 	if channelID == "" {
@@ -143,26 +143,12 @@ func NewCreateChannelTx(channelConfig Channel, channelID string) (*cb.Envelope, 
 		return nil, fmt.Errorf("creating default config template: %v", err)
 	}
 
-	newChannelConfigUpdate, err := newChannelCreateConfigUpdate(channelID, channelConfig, ct)
+	configUpdate, err := newChannelCreateConfigUpdate(channelID, channelConfig, ct)
 	if err != nil {
 		return nil, fmt.Errorf("creating channel create config update: %v", err)
 	}
 
-	configUpdate, err := proto.Marshal(newChannelConfigUpdate)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling new channel config update: %v", err)
-	}
-
-	newConfigUpdateEnv := &cb.ConfigUpdateEnvelope{
-		ConfigUpdate: configUpdate,
-	}
-
-	env, err := newEnvelope(cb.HeaderType_CONFIG_UPDATE, channelID, newConfigUpdateEnv)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create envelope: %v", err)
-	}
-
-	return env, nil
+	return configUpdate, nil
 }
 
 // NewSystemChannelGenesisBlock creates a genesis block using the provided consortiums and orderer

--- a/configtx/config_test.go
+++ b/configtx/config_test.go
@@ -1127,7 +1127,36 @@ func TestNewSystemChannelGenesisBlockFailure(t *testing.T) {
 	}
 }
 
+func TestNewEnvelopeFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		spec         string
+		configUpdate *cb.ConfigUpdate
+		expectedErr  string
+	}{
+		{
+			spec:         "when no config update is provided",
+			configUpdate: nil,
+			expectedErr:  "marshaling config update: proto: Marshal called with nil",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.spec, func(t *testing.T) {
+			t.Parallel()
+			gt := NewGomegaWithT(t)
+
+			env, err := NewEnvelope(tc.configUpdate)
+			gt.Expect(err).To(MatchError(tc.expectedErr))
+			gt.Expect(env).To(BeNil())
+		})
+	}
+}
+
 func TestComputeUpdate(t *testing.T) {
+	t.Parallel()
 	gt := NewGomegaWithT(t)
 
 	value1Name := "foo"

--- a/configtx/config_test.go
+++ b/configtx/config_test.go
@@ -184,15 +184,17 @@ func TestNewCreateChannelTx(t *testing.T) {
 	profile := baseProfile(t)
 
 	// creating a create channel transaction
-	envelope, err := NewCreateChannelTx(profile, "testchannel")
-	gt.Expect(err).ToNot(HaveOccurred())
+	createChannelTx, err := NewCreateChannelTx(profile, "testchannel")
+	gt.Expect(err).NotTo(HaveOccurred())
+	envelope, err := NewEnvelope(createChannelTx)
+	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(envelope).ToNot(BeNil())
 
 	// Unmarshaling actual and expected envelope to set
 	// the expected timestamp to the actual timestamp
 	expectedEnvelope := cb.Envelope{}
 	err = protolator.DeepUnmarshalJSON(bytes.NewBufferString(expectedEnvelopeJSON), &expectedEnvelope)
-	gt.Expect(err).ToNot(HaveOccurred())
+	gt.Expect(err).NotTo(HaveOccurred())
 
 	expectedPayload := cb.Payload{}
 	err = proto.Unmarshal(expectedEnvelope.Payload, &expectedPayload)
@@ -390,8 +392,8 @@ func TestNewCreateChannelTxFailure(t *testing.T) {
 
 			profile := tt.profileMod()
 
-			env, err := NewCreateChannelTx(profile, tt.channelID)
-			gt.Expect(env).To(BeNil())
+			createChannelTx, err := NewCreateChannelTx(profile, tt.channelID)
+			gt.Expect(createChannelTx).To(BeNil())
 			gt.Expect(err).To(MatchError(tt.err))
 		})
 	}

--- a/configtx/example_test.go
+++ b/configtx/example_test.go
@@ -114,8 +114,8 @@ func Example_basic() {
 	}
 
 	for _, si := range signingIdentities {
-		// Sign the config update with the specified signer identity
-		configSignature, err := si.SignConfigUpdate(configUpdate)
+		// Create a signature for the config update with the specified signer identity
+		configSignature, err := si.CreateConfigSignature(configUpdate)
 		if err != nil {
 			panic(err)
 		}
@@ -123,9 +123,14 @@ func Example_basic() {
 		configSignatures = append(configSignatures, configSignature)
 	}
 
-	// Sign the envelope with the list of signatures
-	_, err = peer1SigningIdentity.SignConfigUpdateEnvelope(configUpdate,
-		configSignatures...)
+	// Create the envelope with the list of config signatures
+	env, err := configtx.NewEnvelope(configUpdate, configSignatures...)
+	if err != nil {
+		panic(err)
+	}
+
+	// Sign the envelope with a signing identity
+	err = peer1SigningIdentity.SignEnvelope(env)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
#### Type of change

- New feature
- Improvement (improvement to code, performance, etc)

#### Description

First commit:
- Support returning an unsigned config update envelope
- Refactor signing identity (SignConfigUpdate -> CreateConfigSignature and SignConfigUpdateEnvelope -> SIgnEnvelope)

Second commit:
- Refactor NewCreateChannelTx to return a config update, which allows us to utilize the signing functionality in the library.

#### Related issues

[FAB-17871](https://jira.hyperledger.org/browse/FAB-17871)
[FAB-17872](https://jira.hyperledger.org/browse/FAB-17872)