### PR TITLE
Reintroduce original and updated config retrieval funcs

### DIFF
--- a/configtx/config.go
+++ b/configtx/config.go
@@ -93,6 +93,16 @@ func New(config *cb.Config) ConfigTx {
 	}
 }
 
+// OriginalConfig returns the original unedited config.
+func (c *ConfigTx) OriginalConfig() *cb.Config {
+	return c.original
+}
+
+// UpdatedConfig returns the modified config.
+func (c *ConfigTx) UpdatedConfig() *cb.Config {
+	return c.updated
+}
+
 // ComputeUpdate computes the ConfigUpdate from a base and modified config transaction.
 func (c *ConfigTx) ComputeUpdate(channelID string) (*cb.ConfigUpdate, error) {
 	if channelID == "" {

--- a/configtx/config_test.go
+++ b/configtx/config_test.go
@@ -19,6 +19,29 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func TestNewConfigTx(t *testing.T) {
+	t.Parallel()
+
+	gt := NewGomegaWithT(t)
+
+	channel, _, err := baseApplicationChannelGroup(t)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	original := &cb.Config{
+		ChannelGroup: channel,
+	}
+
+	c := New(original)
+	gt.Expect(proto.Equal(c.OriginalConfig(), original)).To(BeTrue())
+	gt.Expect(proto.Equal(c.UpdatedConfig(), original)).To(BeTrue())
+
+	err = c.Application().AddCapability("fake-capability")
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	gt.Expect(proto.Equal(c.OriginalConfig(), original)).To(BeTrue())
+	gt.Expect(proto.Equal(c.UpdatedConfig(), original)).To(BeFalse())
+}
+
 func TestNewCreateChannelTx(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Reintroduce retrieval functions to ensure we have a way to sanity check that the config matches what we expect when submitting an update using the fabric-config library.

#### Related issues

[FAB-17894](https://jira.hyperledger.org/browse/FAB-17894)