### PR TITLE
[FAB-17949] Remove constraint on expecting orderer endpoints to exist at the org level when updating a config

### DIFF
--- a/configtx/config.go
+++ b/configtx/config.go
@@ -229,15 +229,6 @@ func newSystemChannelGroup(channelConfig Channel) (*cb.ConfigGroup, error) {
 		return nil, err
 	}
 
-	if len(channelConfig.Orderer.Addresses) == 0 {
-		return nil, errors.New("orderer endpoints is not defined in channel config")
-	}
-
-	err = setValue(channelGroup, ordererAddressesValue(channelConfig.Orderer.Addresses), ordererAdminsPolicyName)
-	if err != nil {
-		return nil, err
-	}
-
 	if len(channelConfig.Capabilities) == 0 {
 		return nil, errors.New("capabilities is not defined in channel config")
 	}
@@ -306,22 +297,6 @@ func implicitMetaFromString(input string) (*cb.ImplicitMetaPolicy, error) {
 	}
 
 	return res, nil
-}
-
-// ordererAddressesValue returns the a config definition for the orderer addresses.
-// It is a value for the /Channel group.
-func ordererAddressesValue(addresses []Address) *standardConfigValue {
-	var addrs []string
-	for _, a := range addresses {
-		addrs = append(addrs, fmt.Sprintf("%s:%d", a.Host, a.Port))
-	}
-
-	return &standardConfigValue{
-		key: OrdererAddressesKey,
-		value: &cb.OrdererAddresses{
-			Addresses: addrs,
-		},
-	}
 }
 
 // mspValue returns the config definition for an MSP.

--- a/configtx/config_test.go
+++ b/configtx/config_test.go
@@ -989,15 +989,6 @@ func TestNewSystemChannelGenesisBlock(t *testing.T) {
 											}
 										},
 										"version": "0"
-									},
-									"OrdererAddresses": {
-										"mod_policy": "/Channel/Orderer/Admins",
-										"value": {
-											"addresses": [
-												"localhost:123"
-											]
-										},
-										"version": "0"
 									}
 								},
 								"version": "0"
@@ -1108,11 +1099,11 @@ func TestNewSystemChannelGenesisBlockFailure(t *testing.T) {
 			testName: "When creating the default system config template with empty orderer endpoints",
 			profileMod: func() Channel {
 				profile, _, _ := baseSystemChannelProfile(t)
-				profile.Orderer.Addresses = []Address{}
+				profile.Orderer.Organizations[0].OrdererEndpoints = []string{}
 				return profile
 			},
 			channelID: "testsystemchannel",
-			err:       errors.New("creating system channel group: orderer endpoints is not defined in channel config"),
+			err:       errors.New("creating system channel group: orderer endpoints are not defined for org OrdererOrg"),
 		},
 		{
 			testName: "When creating the default config template with empty capabilities",
@@ -1132,7 +1123,7 @@ func TestNewSystemChannelGenesisBlockFailure(t *testing.T) {
 				return profile
 			},
 			channelID: "testsystemchannel",
-			err:       errors.New("creating system channel group: orderer endpoints is not defined in channel config"),
+			err:       errors.New("creating system channel group: no policies defined"),
 		},
 	}
 

--- a/configtx/constants.go
+++ b/configtx/constants.go
@@ -23,9 +23,6 @@ const (
 	// of a BlockDataHashingStructure.
 	BlockDataHashingStructureKey = "BlockDataHashingStructure"
 
-	// OrdererAddressesKey is the key for the ConfigValue, OrdererAddresses.
-	OrdererAddressesKey = "OrdererAddresses"
-
 	// CapabilitiesKey is the key for the ConfigValue, capabilities.
 	// CapabiltiesKey can be used at the channel, application, and orderer levels.
 	CapabilitiesKey = "Capabilities"

--- a/configtx/example_test.go
+++ b/configtx/example_test.go
@@ -434,13 +434,7 @@ func ExampleNewSystemChannelGenesisBlock() {
 				PreferredMaxBytes: 100,
 			},
 			BatchTimeout: 2 * time.Second,
-			Addresses: []configtx.Address{
-				{
-					Host: "localhost",
-					Port: 123,
-				},
-			},
-			State: orderer.ConsensusStateNormal,
+			State:        orderer.ConsensusStateNormal,
 		},
 		Capabilities: []string{"V2_0"},
 		Policies: map[string]configtx.Policy{
@@ -816,14 +810,7 @@ func fetchChannelConfig() *cb.Config {
 					},
 				},
 			},
-			Values: map[string]*cb.ConfigValue{
-				configtx.OrdererAddressesKey: {
-					Value: marshalOrPanic(&cb.OrdererAddresses{
-						Addresses: []string{"127.0.0.1:7050"},
-					}),
-					ModPolicy: configtx.AdminsPolicyKey,
-				},
-			},
+			Values: map[string]*cb.ConfigValue{},
 			Policies: map[string]*cb.ConfigPolicy{
 				configtx.AdminsPolicyKey: {
 					ModPolicy: configtx.AdminsPolicyKey,


### PR DESCRIPTION
* Remove the concept of top level OrdererAddresses as a field that can
be modified/updated or set when creating a new system channel genesis
block
* Introduce requirement that orderer orgs must have orderer endpoints
defined when creating a new system channel genesis block

https://jira.hyperledger.org/browse/FAB-17949