### PR TITLE
[FAB-17949] Remove org level constraint when retrieving orderer org configuration for requiring orderer endpoints to exist

### DIFF
--- a/configtx/orderer.go
+++ b/configtx/orderer.go
@@ -192,17 +192,21 @@ func (o *OrdererOrg) Configuration() (Organization, error) {
 		return Organization{}, err
 	}
 
-	// Orderer organization requires orderer endpoints.
-	endpointsProtos := &cb.OrdererAddresses{}
-	err = unmarshalConfigValueAtKey(o.orgGroup, EndpointsKey, endpointsProtos)
-	if err != nil {
-		return Organization{}, err
+	// OrdererEndpoints are optional when retrieving from an existing config
+	org.OrdererEndpoints = nil
+	_, ok := o.orgGroup.Values[EndpointsKey]
+	if ok {
+		endpointsProtos := &cb.OrdererAddresses{}
+		err = unmarshalConfigValueAtKey(o.orgGroup, EndpointsKey, endpointsProtos)
+		if err != nil {
+			return Organization{}, err
+		}
+		ordererEndpoints := make([]string, len(endpointsProtos.Addresses))
+		for i, address := range endpointsProtos.Addresses {
+			ordererEndpoints[i] = address
+		}
+		org.OrdererEndpoints = ordererEndpoints
 	}
-	ordererEndpoints := make([]string, len(endpointsProtos.Addresses))
-	for i, address := range endpointsProtos.Addresses {
-		ordererEndpoints[i] = address
-	}
-	org.OrdererEndpoints = ordererEndpoints
 
 	// Remove AnchorPeers which are application org specific.
 	org.AnchorPeers = nil

--- a/configtx/orderer_test.go
+++ b/configtx/orderer_test.go
@@ -1241,6 +1241,35 @@ func TestOrdererConfiguration(t *testing.T) {
 	}
 }
 
+func TestOrdererConfigurationNoOrdererEndpoints(t *testing.T) {
+	t.Parallel()
+
+	gt := NewGomegaWithT(t)
+
+	baseOrdererConf, _ := baseOrdererOfType(t, orderer.ConsensusTypeSolo)
+
+	ordererGroup, err := newOrdererGroup(baseOrdererConf)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	config := &cb.Config{
+		ChannelGroup: &cb.ConfigGroup{
+			Groups: map[string]*cb.ConfigGroup{
+				OrdererGroupKey: ordererGroup,
+			},
+			Values: map[string]*cb.ConfigValue{},
+		},
+	}
+
+	delete(config.ChannelGroup.Groups[OrdererGroupKey].Groups["OrdererOrg"].Values, EndpointsKey)
+
+	c := New(config)
+
+	ordererConf, err := c.Orderer().Configuration()
+	gt.Expect(err).NotTo(HaveOccurred())
+	baseOrdererConf.Organizations[0].OrdererEndpoints = nil
+	gt.Expect(ordererConf).To(Equal(baseOrdererConf))
+}
+
 func TestOrdererConfigurationFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Missed this in the last PR for removing constraints on the orderer endpoints. Apparently there was another check we do when retrieving orderer org configuration that I missed originally.