### PR TITLE
Only proto.Marshal ConfigUpdate once to ensure signatures are valid

### DIFF
--- a/configtx/config.go
+++ b/configtx/config.go
@@ -103,32 +103,40 @@ func (c *ConfigTx) UpdatedConfig() *cb.Config {
 	return c.updated
 }
 
-// ComputeUpdate computes the ConfigUpdate from a base and modified config transaction.
-func (c *ConfigTx) ComputeUpdate(channelID string) (*cb.ConfigUpdate, error) {
+// ComputeMarshaledUpdate computes the ConfigUpdate from a base and modified
+// config transaction and returns the marshaled bytes.
+func (c *ConfigTx) ComputeMarshaledUpdate(channelID string) ([]byte, error) {
 	if channelID == "" {
 		return nil, errors.New("channel ID is required")
 	}
 
-	updt, err := computeConfigUpdate(c.original, c.updated)
+	update, err := computeConfigUpdate(c.original, c.updated)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute update: %v", err)
 	}
 
-	updt.ChannelId = channelID
+	update.ChannelId = channelID
 
-	return updt, nil
-}
-
-// NewEnvelope creates an envelope with the provided config update and config signatures.
-func NewEnvelope(c *cb.ConfigUpdate, signatures ...*cb.ConfigSignature) (*cb.Envelope, error) {
-	cBytes, err := proto.Marshal(c)
+	marshaledUpdate, err := proto.Marshal(update)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling config update: %v", err)
 	}
 
+	return marshaledUpdate, nil
+}
+
+// NewEnvelope creates an envelope with the provided marshaled config update
+// and config signatures.
+func NewEnvelope(marshaledUpdate []byte, signatures ...*cb.ConfigSignature) (*cb.Envelope, error) {
 	configUpdateEnvelope := &cb.ConfigUpdateEnvelope{
-		ConfigUpdate: cBytes,
+		ConfigUpdate: marshaledUpdate,
 		Signatures:   signatures,
+	}
+
+	c := &cb.ConfigUpdate{}
+	err := proto.Unmarshal(marshaledUpdate, c)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshaling config update: %v", err)
 	}
 
 	envelope, err := newEnvelope(cb.HeaderType_CONFIG_UPDATE, c.ChannelId, configUpdateEnvelope)
@@ -139,11 +147,10 @@ func NewEnvelope(c *cb.ConfigUpdate, signatures ...*cb.ConfigSignature) (*cb.Env
 	return envelope, nil
 }
 
-// NewCreateChannelTx creates a create channel config update transaction using the
-// provided application channel configuration.
-func NewCreateChannelTx(channelConfig Channel, channelID string) (*cb.ConfigUpdate, error) {
-	var err error
-
+// NewMarshaledCreateChannelTx creates a create channel config update
+// transaction using the provided application channel configuration and returns
+// the marshaled bytes.
+func NewMarshaledCreateChannelTx(channelConfig Channel, channelID string) ([]byte, error) {
 	if channelID == "" {
 		return nil, errors.New("profile's channel ID is required")
 	}
@@ -153,12 +160,16 @@ func NewCreateChannelTx(channelConfig Channel, channelID string) (*cb.ConfigUpda
 		return nil, fmt.Errorf("creating default config template: %v", err)
 	}
 
-	configUpdate, err := newChannelCreateConfigUpdate(channelID, channelConfig, ct)
+	update, err := newChannelCreateConfigUpdate(channelID, channelConfig, ct)
 	if err != nil {
 		return nil, fmt.Errorf("creating channel create config update: %v", err)
 	}
 
-	return configUpdate, nil
+	marshaledUpdate, err := proto.Marshal(update)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling config update: %v", err)
+	}
+	return marshaledUpdate, nil
 }
 
 // NewSystemChannelGenesisBlock creates a genesis block using the provided consortiums and orderer

--- a/configtx/example_test.go
+++ b/configtx/example_test.go
@@ -95,7 +95,7 @@ func Example_basic() {
 	}
 
 	// Compute the delta
-	configUpdate, err := c.ComputeUpdate("testsyschannel")
+	marshaledUpdate, err := c.ComputeMarshaledUpdate("testsyschannel")
 	if err != nil {
 		panic(err)
 	}
@@ -115,7 +115,7 @@ func Example_basic() {
 
 	for _, si := range signingIdentities {
 		// Create a signature for the config update with the specified signer identity
-		configSignature, err := si.CreateConfigSignature(configUpdate)
+		configSignature, err := si.CreateConfigSignature(marshaledUpdate)
 		if err != nil {
 			panic(err)
 		}
@@ -124,7 +124,7 @@ func Example_basic() {
 	}
 
 	// Create the envelope with the list of config signatures
-	env, err := configtx.NewEnvelope(configUpdate, configSignatures...)
+	env, err := configtx.NewEnvelope(marshaledUpdate, configSignatures...)
 	if err != nil {
 		panic(err)
 	}
@@ -461,7 +461,7 @@ func ExampleNewSystemChannelGenesisBlock() {
 	}
 }
 
-func ExampleNewCreateChannelTx() {
+func ExampleNewMarshaledCreateChannelTx() {
 	channel := configtx.Channel{
 		Consortium: "SampleConsortium",
 		Application: configtx.Application{
@@ -502,7 +502,7 @@ func ExampleNewCreateChannelTx() {
 		},
 	}
 
-	_, err := configtx.NewCreateChannelTx(channel, "testchannel")
+	_, err := configtx.NewMarshaledCreateChannelTx(channel, "testchannel")
 	if err != nil {
 		panic(err)
 	}

--- a/configtx/signer.go
+++ b/configtx/signer.go
@@ -90,7 +90,7 @@ func toLowS(key ecdsa.PublicKey, sig ecdsaSignature) ecdsaSignature {
 
 // CreateConfigSignature creates a config signature for the the given configuration
 // update using the specified signing identity.
-func (s *SigningIdentity) CreateConfigSignature(configUpdate *cb.ConfigUpdate) (*cb.ConfigSignature, error) {
+func (s *SigningIdentity) CreateConfigSignature(marshaledUpdate []byte) (*cb.ConfigSignature, error) {
 	signatureHeader, err := s.signatureHeader()
 	if err != nil {
 		return nil, fmt.Errorf("creating signature header: %v", err)
@@ -105,14 +105,9 @@ func (s *SigningIdentity) CreateConfigSignature(configUpdate *cb.ConfigUpdate) (
 		SignatureHeader: header,
 	}
 
-	configUpdateBytes, err := proto.Marshal(configUpdate)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling config update: %v", err)
-	}
-
 	configSignature.Signature, err = s.Sign(
 		rand.Reader,
-		concatenateBytes(configSignature.SignatureHeader, configUpdateBytes),
+		concatenateBytes(configSignature.SignatureHeader, marshaledUpdate),
 		nil,
 	)
 	if err != nil {


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Due to the non-deterministic nature of proto.Marshal, the configtx library should marshal the config update once and pass the marshaled bytes around for signatures. This particularly causes problems with updates involving AnchorPeers, hence the specific unit test verifying signatures for an anchor peer update envelope.

#### Related issues

[FAB-17959](https://jira.hyperledger.org/browse/FAB-17959)