### PR TITLE
[FAB-17950] Implement removal of orderer endpoints from toplevel channel

### DIFF
--- a/configtx/channel.go
+++ b/configtx/channel.go
@@ -142,3 +142,11 @@ func (c *ChannelGroup) RemoveCapability(capability string) error {
 
 	return nil
 }
+
+// RemoveLegacyOrdererAddresses removes the deprecated top level orderer addresses config key and value
+// from the channel config.
+// In fabric 1.4, top level orderer addresses were migrated to the org level orderer endpoints
+// While top-level orderer addresses are still supported, the organization value is preferred.
+func (c *ChannelGroup) RemoveLegacyOrdererAddresses() {
+	delete(c.channelGroup.Values, OrdererAddressesKey)
+}

--- a/configtx/channel_test.go
+++ b/configtx/channel_test.go
@@ -319,3 +319,28 @@ func TestRemoveChannelPolicyFailures(t *testing.T) {
 	err = c.Channel().RemovePolicy(ReadersPolicyKey)
 	gt.Expect(err).To(MatchError("unknown policy type: 15"))
 }
+
+func TestRemoveLegacyOrdererAddresses(t *testing.T) {
+	t.Parallel()
+	gt := NewGomegaWithT(t)
+
+	config := &cb.Config{
+		ChannelGroup: &cb.ConfigGroup{
+			Values: map[string]*cb.ConfigValue{
+				OrdererAddressesKey: {
+					ModPolicy: AdminsPolicyKey,
+					Value: marshalOrPanic(&cb.OrdererAddresses{
+						Addresses: []string{"127.0.0.1:8050"},
+					}),
+				},
+			},
+		},
+	}
+
+	c := New(config)
+
+	c.Channel().RemoveLegacyOrdererAddresses()
+
+	_, exists := c.Channel().channelGroup.Values[OrdererAddressesKey]
+	gt.Expect(exists).To(BeFalse())
+}

--- a/configtx/constants.go
+++ b/configtx/constants.go
@@ -84,4 +84,7 @@ const (
 	SignaturePolicyType = "Signature"
 
 	ordererAdminsPolicyName = "/Channel/Orderer/Admins"
+
+	// OrdererAddressesKey is the key for the ConfigValue of OrdererAddresses.
+	OrdererAddressesKey = "OrdererAddresses"
 )


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Implement removal of orderer addresses from the top level of a new ConfigTx's channel group to remove the legacy config value.

#### Related issues

[FAB-17950](https://jira.hyperledger.org/browse/FAB-17950)
