### PR TITLE
[FAB-18047] Implement kafka brokers removal function

### DIFF
--- a/configtx/example_test.go
+++ b/configtx/example_test.go
@@ -584,6 +584,28 @@ func ExampleConsortiumOrg_SetMSP() {
 	}
 }
 
+func ExampleOrdererGroup_RemoveLegacyKafkaBrokers() {
+
+	baseConfig := fetchChannelConfig()
+	c := configtx.New(baseConfig)
+	ordererConfig, err := c.Orderer().Configuration()
+	if err != nil {
+		panic(err)
+	}
+	ordererConfig.OrdererType = orderer.ConsensusTypeEtcdRaft
+	ordererConfig.EtcdRaft = orderer.EtcdRaft{
+		Consenters: []orderer.Consenter{
+			{Address: orderer.EtcdAddress{
+				Host: "host1",
+				Port: 7050},
+				ClientTLSCert: generateCert(),
+				ServerTLSCert: generateCert(),
+			},
+		},
+	}
+	c.Orderer().RemoveLegacyKafkaBrokers()
+}
+
 // fetchChannelConfig mocks retrieving the config transaction from the most recent configuration block.
 func fetchChannelConfig() *cb.Config {
 	return &cb.Config{

--- a/configtx/orderer.go
+++ b/configtx/orderer.go
@@ -539,6 +539,12 @@ func (o *OrdererOrg) Policies() (map[string]Policy, error) {
 	return getPolicies(o.orgGroup.Policies)
 }
 
+// RemoveLegacyKafkaBrokers removes the legacy kafka brokers config key and value from config.
+// In fabric 2.0, kafka was deprecated as a consensus type.
+func (o *OrdererGroup) RemoveLegacyKafkaBrokers() {
+	delete(o.ordererGroup.Values, orderer.KafkaBrokersKey)
+}
+
 // newOrdererGroup returns the orderer component of the channel configuration.
 // It defines parameters of the ordering service about how large blocks should be,
 // how frequently they should be emitted, etc. as well as the organizations of the ordering network.

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,4 @@ require (
 	github.com/golang/protobuf v1.3.3
 	github.com/hyperledger/fabric-protos-go v0.0.0-20200424173316-dd554ba3746e
 	github.com/onsi/gomega v1.9.0
-	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 )


### PR DESCRIPTION
Signed-off-by: Arturo Cabre <arturo@ibm.com>

#### Type of change

- New feature

#### Description

Added a function to remove KafkaBrokers from Orderer config. Useful when migrating to Raft. 

#### Related issues
https://jira.hyperledger.org/browse/FAB-18047