### PR TITLE
[FAB-18262] Fix wrong comments on OrdererType options

### DIFF
--- a/configtx/internal/policydsl/policyparser.go
+++ b/configtx/internal/policydsl/policyparser.go
@@ -172,7 +172,7 @@ func secondPass(args ...interface{}) (interface{}, error) {
 	}
 
 	/* get the n in the t out of n */
-	var n int = len(args) - 2
+	var n = len(args) - 2
 
 	/* sanity check - t should be positive, permit equal to n+1, but disallow over n+1 */
 	if t < 0 || t > n+1 {

--- a/configtx/orderer.go
+++ b/configtx/orderer.go
@@ -30,7 +30,7 @@ const (
 // Orderer configures the ordering service behavior for a channel.
 type Orderer struct {
 	// OrdererType is the type of orderer
-	// Options: `Solo`, `Kafka` or `Raft`
+	// Options: `ConsensusTypeSolo`, `ConsensusTypeKafka` or `ConsensusTypeEtcdRaft`
 	OrdererType string
 	// BatchTimeout is the wait time between transactions.
 	BatchTimeout  time.Duration


### PR DESCRIPTION
This patch replaces wrong comments on `OrdererType` options with the correct constants `ConsensusTypeSolo`, `ConsensusTypeKafka` and `ConsensusTypeEtcdRaft`.

Also, this patch includes a minor fix to pass lint checks.

#### Type of change

- Bug fix

#### Description

Currently, the OrdererType options are described in the comments in `configtx/orderer.go` as follows:

```
    // OrdererType is the type of orderer
    // Options: `Solo`, `Kafka` or `Raft
```

These `Solo`, `Kafka` or `Raft` don’t seem to be the correct strings to give to OrdererType.
In fact, configtx lib raises an error like when the above strings are given.

This patch replaces the wrong comments on `OrdererType` options with the correct constants `ConsensusTypeSolo`, `ConsensusTypeKafka` and `ConsensusTypeEtcdRaft` to avoid misunderstanding by users.


#### Related issues

- https://jira.hyperledger.org/browse/FAB-18262