### PR TITLE
[FAB-18264] Allow cb.Config with no ACLs to be loaded

### DIFF
--- a/configtx/application.go
+++ b/configtx/application.go
@@ -336,11 +336,16 @@ func (a *ApplicationOrg) RemoveAnchorPeer(anchorPeerToRemove Address) error {
 
 // ACLs returns a map of ACLS for given config application.
 func (a *ApplicationGroup) ACLs() (map[string]string, error) {
+	aclConfigValue, ok := a.applicationGroup.Values[ACLsKey]
+	if !ok {
+		return nil, nil
+	}
+
 	aclProtos := &pb.ACLs{}
 
-	err := unmarshalConfigValueAtKey(a.applicationGroup, ACLsKey, aclProtos)
+	err := proto.Unmarshal(aclConfigValue.Value, aclProtos)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unmarshaling %s: %v", ACLsKey, err)
 	}
 
 	retACLs := map[string]string{}

--- a/configtx/application_test.go
+++ b/configtx/application_test.go
@@ -1033,6 +1033,31 @@ func TestApplicationACLs(t *testing.T) {
 	gt.Expect(applicationACLs).To(Equal(baseApplicationConf.ACLs))
 }
 
+func TestEmptyApplicationACLs(t *testing.T) {
+	t.Parallel()
+
+	gt := NewGomegaWithT(t)
+
+	baseApplicationConf, _ := baseApplication(t)
+	baseApplicationConf.ACLs = nil
+	applicationGroup, err := newApplicationGroupTemplate(baseApplicationConf)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	config := &cb.Config{
+		ChannelGroup: &cb.ConfigGroup{
+			Groups: map[string]*cb.ConfigGroup{
+				ApplicationGroupKey: applicationGroup,
+			},
+		},
+	}
+
+	c := New(config)
+
+	applicationACLs, err := c.Application().ACLs()
+	gt.Expect(err).NotTo(HaveOccurred())
+	gt.Expect(applicationACLs).To(BeNil())
+}
+
 func TestApplicationACLsFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This patch allows Config Transaction Library to load cb.Config which does not contain any values for ACLs.

#### Type of change

- Bug fix

#### Description

Currently, ConfigTx Library gives errors when reading `cb.Config` which does not contain values for ACLs.

Example of error:
```
config does not contain value for ACLs
retrieving application acls: config does not contain value for ACLs
```

On the other hand, In the actual Fabric channel settings, ACLs may not be set.
This is because the default value is used if it is not set.
- e.g., fabric-samples/test-network does not set ACLs (refer to configtx.yaml).
- ConfigTx Library seems to be able to create ConfigTX with empty ACLs.

So, this patch allows Config Transaction Library to load cb.Config which does not contain any values for ACLs.

#### Related issues

- https://jira.hyperledger.org/browse/FAB-18264