### PR TITLE
[FAB-18268] Add SetPolicies() to easily replace multiple policies in an existing configuration with the given policies

### DIFF
--- a/configtx/application.go
+++ b/configtx/application.go
@@ -187,6 +187,17 @@ func (a *ApplicationGroup) SetPolicy(modPolicy, policyName string, policy Policy
 	return nil
 }
 
+// SetPolicies sets the specified policies in the application group's config policy map.
+// If the policies already exist in current configuration, the values will be replaced with new policies.
+func (a *ApplicationGroup) SetPolicies(modPolicy string, policies map[string]Policy) error {
+	err := setPolicies(a.applicationGroup, policies, modPolicy)
+	if err != nil {
+		return fmt.Errorf("failed to set policies: %v", err)
+	}
+
+	return nil
+}
+
 // RemovePolicy removes an existing policy from an application's configuration.
 // Removal will panic if the application group does not exist.
 func (a *ApplicationGroup) RemovePolicy(policyName string) error {

--- a/configtx/application.go
+++ b/configtx/application.go
@@ -139,7 +139,7 @@ func (a *ApplicationGroup) Capabilities() ([]string, error) {
 }
 
 // AddCapability sets capability to the provided channel config.
-// If the provided capability already exist in current configuration, this action
+// If the provided capability already exists in current configuration, this action
 // will be a no-op.
 func (a *ApplicationGroup) AddCapability(capability string) error {
 	capabilities, err := a.Capabilities()
@@ -177,7 +177,7 @@ func (a *ApplicationGroup) Policies() (map[string]Policy, error) {
 }
 
 // SetPolicy sets the specified policy in the application group's config policy map.
-// If the policy already exist in current configuration, its value will be overwritten.
+// If the policy already exists in current configuration, its value will be overwritten.
 func (a *ApplicationGroup) SetPolicy(modPolicy, policyName string, policy Policy) error {
 	err := setPolicy(a.applicationGroup, modPolicy, policyName, policy)
 	if err != nil {
@@ -211,13 +211,13 @@ func (a *ApplicationGroup) RemovePolicy(policyName string) error {
 }
 
 // Policies returns the map of policies for a specific application org in
-// the updated config..
+// the updated config.
 func (a *ApplicationOrg) Policies() (map[string]Policy, error) {
 	return getPolicies(a.orgGroup.Policies)
 }
 
 // SetPolicy sets the specified policy in the application org group's config policy map.
-// If an Organization policy already exist in current configuration, its value will be overwritten.
+// If an Organization policy already exists in current configuration, its value will be overwritten.
 func (a *ApplicationOrg) SetPolicy(modPolicy, policyName string, policy Policy) error {
 	err := setPolicy(a.orgGroup, modPolicy, policyName, policy)
 	if err != nil {
@@ -374,7 +374,7 @@ func (a *ApplicationGroup) ACLs() (map[string]string, error) {
 }
 
 // SetACLs sets ACLS to an existing channel config application.
-// If an ACL already exist in current configuration, it will be replaced with new ACL.
+// If an ACL already exists in current configuration, it will be replaced with new ACL.
 func (a *ApplicationGroup) SetACLs(acls map[string]string) error {
 	err := setValue(a.applicationGroup, aclValues(acls), AdminsPolicyKey)
 	if err != nil {

--- a/configtx/application.go
+++ b/configtx/application.go
@@ -227,6 +227,17 @@ func (a *ApplicationOrg) SetPolicy(modPolicy, policyName string, policy Policy) 
 	return nil
 }
 
+// SetPolicies sets the specified policies in the application org group's config policy map.
+// If the policies already exist in current configuration, the values will be replaced with new policies.
+func (a *ApplicationOrg) SetPolicies(modPolicy string, policies map[string]Policy) error {
+	err := setPolicies(a.orgGroup, policies, modPolicy)
+	if err != nil {
+		return fmt.Errorf("failed to set policies: %v", err)
+	}
+
+	return nil
+}
+
 // RemovePolicy removes an existing policy from an application organization.
 func (a *ApplicationOrg) RemovePolicy(policyName string) error {
 	policies, err := a.Policies()

--- a/configtx/application_test.go
+++ b/configtx/application_test.go
@@ -1735,6 +1735,124 @@ func TestSetApplicationOrgPolicyFailures(t *testing.T) {
 	gt.Expect(err).To(MatchError("failed to set policy 'TestPolicy': unknown policy type: "))
 }
 
+func TestSetApplicationOrgPolicies(t *testing.T) {
+	t.Parallel()
+	gt := NewGomegaWithT(t)
+
+	channelGroup := newConfigGroup()
+	applicationGroup := newConfigGroup()
+
+	application, _ := baseApplication(t)
+
+	for _, org := range application.Organizations {
+		org.Policies = applicationOrgStandardPolicies()
+		org.Policies["TestPolicy_Remove"] = org.Policies[EndorsementPolicyKey]
+
+		orgGroup, err := newOrgConfigGroup(org)
+		gt.Expect(err).NotTo(HaveOccurred())
+
+		applicationGroup.Groups[org.Name] = orgGroup
+	}
+	channelGroup.Groups[ApplicationGroupKey] = applicationGroup
+	config := &cb.Config{
+		ChannelGroup: channelGroup,
+	}
+
+	c := New(config)
+
+	applicationOrg1 := c.Application().Organization("Org1")
+	policies := map[string]Policy{
+		ReadersPolicyKey: {
+			Type: ImplicitMetaPolicyType,
+			Rule: "ANY Readers",
+		},
+		WritersPolicyKey: {
+			Type: ImplicitMetaPolicyType,
+			Rule: "ANY Writers",
+		},
+		AdminsPolicyKey: {
+			Type: ImplicitMetaPolicyType,
+			Rule: "MAJORITY Admins",
+		},
+		EndorsementPolicyKey: {
+			Type: ImplicitMetaPolicyType,
+			Rule: "MAJORITY Endorsement",
+		},
+		LifecycleEndorsementPolicyKey: {
+			Type: ImplicitMetaPolicyType,
+			Rule: "MAJORITY Endorsement",
+		},
+		"TestPolicy_Add1": {
+			Type: ImplicitMetaPolicyType,
+			Rule: "MAJORITY Endorsement",
+		},
+		"TestPolicy_Add2": {
+			Type: ImplicitMetaPolicyType,
+			Rule: "MAJORITY Endorsement",
+		},
+	}
+	err := applicationOrg1.SetPolicies(AdminsPolicyKey, policies)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	updatedPolicies, err := applicationOrg1.Policies()
+	gt.Expect(err).NotTo(HaveOccurred())
+	gt.Expect(updatedPolicies).To(Equal(policies))
+
+	originalPolicies := c.original.ChannelGroup.Groups[ApplicationGroupKey].Groups["Org1"].Policies
+	gt.Expect(originalPolicies).To(Equal(applicationGroup.Groups["Org1"].Policies))
+}
+
+func TestSetApplicationOrgPoliciesFailures(t *testing.T) {
+	t.Parallel()
+	gt := NewGomegaWithT(t)
+
+	channelGroup := newConfigGroup()
+	applicationGroup := newConfigGroup()
+
+	application, _ := baseApplication(t)
+	for _, org := range application.Organizations {
+		org.Policies = applicationOrgStandardPolicies()
+
+		orgGroup, err := newOrgConfigGroup(org)
+		gt.Expect(err).NotTo(HaveOccurred())
+
+		applicationGroup.Groups[org.Name] = orgGroup
+	}
+	channelGroup.Groups[ApplicationGroupKey] = applicationGroup
+	config := &cb.Config{
+		ChannelGroup: channelGroup,
+	}
+
+	c := New(config)
+
+	policies := map[string]Policy{
+		ReadersPolicyKey: {
+			Type: ImplicitMetaPolicyType,
+			Rule: "ANY Readers",
+		},
+		WritersPolicyKey: {
+			Type: ImplicitMetaPolicyType,
+			Rule: "ANY Writers",
+		},
+		AdminsPolicyKey: {
+			Type: ImplicitMetaPolicyType,
+			Rule: "MAJORITY Admins",
+		},
+		EndorsementPolicyKey: {
+			Type: ImplicitMetaPolicyType,
+			Rule: "MAJORITY Endorsement",
+		},
+		LifecycleEndorsementPolicyKey: {
+			Type: ImplicitMetaPolicyType,
+			Rule: "MAJORITY Endorsement",
+		},
+		"TestPolicy": {},
+	}
+
+	err := c.Application().Organization("Org1").SetPolicies(AdminsPolicyKey, policies)
+	gt.Expect(err).To(MatchError("failed to set policies: unknown policy type: "))
+}
+
 func TestSetApplicationPolicy(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)

--- a/configtx/channel.go
+++ b/configtx/channel.go
@@ -89,6 +89,12 @@ func (c *ChannelGroup) SetPolicy(modPolicy, policyName string, policy Policy) er
 	return setPolicy(c.channelGroup, modPolicy, policyName, policy)
 }
 
+// SetPolicies sets the specified policies in the channel group's config policy map.
+// If the policies already exist in current configuration, the values will be replaced with new policies.
+func (c *ChannelGroup) SetPolicies(modPolicy string, policies map[string]Policy) error {
+	return setPolicies(c.channelGroup, policies, modPolicy)
+}
+
 // RemovePolicy removes an existing channel level policy.
 func (c *ChannelGroup) RemovePolicy(policyName string) error {
 	policies, err := c.Policies()

--- a/configtx/channel.go
+++ b/configtx/channel.go
@@ -84,7 +84,7 @@ func (c *ChannelGroup) Policies() (map[string]Policy, error) {
 }
 
 // SetPolicy sets the specified policy in the channel group's config policy map.
-// If the policy already exist in current configuration, its value will be overwritten.
+// If the policy already exists in current configuration, its value will be overwritten.
 func (c *ChannelGroup) SetPolicy(modPolicy, policyName string, policy Policy) error {
 	return setPolicy(c.channelGroup, modPolicy, policyName, policy)
 }
@@ -118,7 +118,7 @@ func (c *ChannelGroup) Capabilities() ([]string, error) {
 }
 
 // AddCapability adds capability to the provided channel config.
-// If the provided capability already exist in current configuration, this action
+// If the provided capability already exists in current configuration, this action
 // will be a no-op.
 func (c *ChannelGroup) AddCapability(capability string) error {
 	capabilities, err := c.Capabilities()

--- a/configtx/consortiums.go
+++ b/configtx/consortiums.go
@@ -240,6 +240,17 @@ func (c *ConsortiumOrg) SetPolicy(name string, policy Policy) error {
 	return nil
 }
 
+// SetPolicies sets the specified policies in the consortium org group's config policy map.
+// If the policies already exist in current configuration, the values will be replaced with new policies.
+func (c *ConsortiumOrg) SetPolicies(policies map[string]Policy) error {
+	err := setPolicies(c.orgGroup, policies, AdminsPolicyKey)
+	if err != nil {
+		return fmt.Errorf("failed to set policies to consortium org '%s': %v", c.name, err)
+	}
+
+	return nil
+}
+
 // RemovePolicy removes an existing policy from a consortium's organization.
 // Removal will panic if either the consortiums group, consortium group, or consortium org group does not exist.
 func (c *ConsortiumOrg) RemovePolicy(name string) {

--- a/configtx/consortiums.go
+++ b/configtx/consortiums.go
@@ -204,7 +204,7 @@ func (c *ConsortiumOrg) setMSPConfig(updatedMSP MSP) error {
 
 // SetChannelCreationPolicy sets the ConsortiumChannelCreationPolicy for
 // the given configuration Group.
-// If the policy already exist in current configuration, its value will be overwritten.
+// If the policy already exists in current configuration, its value will be overwritten.
 func (c *ConsortiumGroup) SetChannelCreationPolicy(policy Policy) error {
 	imp, err := implicitMetaFromString(policy.Rule)
 	if err != nil {
@@ -230,7 +230,7 @@ func (c *ConsortiumOrg) Policies() (map[string]Policy, error) {
 }
 
 // SetPolicy sets the specified policy in the consortium org group's config policy map.
-// If the policy already exist in current configuration, its value will be overwritten.
+// If the policy already exists in current configuration, its value will be overwritten.
 func (c *ConsortiumOrg) SetPolicy(name string, policy Policy) error {
 	err := setPolicy(c.orgGroup, AdminsPolicyKey, name, policy)
 	if err != nil {

--- a/configtx/orderer.go
+++ b/configtx/orderer.go
@@ -686,9 +686,15 @@ func (o *OrdererOrg) SetMSP(updatedMSP MSP) error {
 }
 
 // SetPolicy sets the specified policy in the orderer org group's config policy map.
-// If the policy already exist in current configuration, its value will be overwritten.
+// If the policy already exists in current configuration, its value will be overwritten.
 func (o *OrdererOrg) SetPolicy(modPolicy, policyName string, policy Policy) error {
 	return setPolicy(o.orgGroup, modPolicy, policyName, policy)
+}
+
+// SetPolicies sets the specified policies in the orderer org group's config policy map.
+// If the policies already exist in current configuration, the values will be replaced with new policies.
+func (o *OrdererOrg) SetPolicies(modPolicy string, policies map[string]Policy) error {
+	return setPolicies(o.orgGroup, policies, modPolicy)
 }
 
 // RemovePolicy removes an existing policy from an orderer organization.

--- a/configtx/orderer.go
+++ b/configtx/orderer.go
@@ -623,6 +623,22 @@ func (o *OrdererGroup) SetPolicy(modPolicy, policyName string, policy Policy) er
 	return nil
 }
 
+// SetPolicies sets the specified policy in the orderer group's config policy map.
+// If the policies already exist in current configuration, the values will be replaced with new policies.
+func (o *OrdererGroup) SetPolicies(modPolicy string, policies map[string]Policy) error {
+
+	if _, ok := policies[BlockValidationPolicyKey]; !ok {
+		return errors.New("BlockValidation policy must be defined")
+	}
+
+	err := setPolicies(o.ordererGroup, policies, modPolicy)
+	if err != nil {
+		return fmt.Errorf("failed to set policies: %v", err)
+	}
+
+	return nil
+}
+
 // RemovePolicy removes an existing orderer policy configuration.
 func (o *OrdererGroup) RemovePolicy(policyName string) error {
 	if policyName == BlockValidationPolicyKey {

--- a/configtx/orderer.go
+++ b/configtx/orderer.go
@@ -519,7 +519,7 @@ func (o *OrdererGroup) Capabilities() ([]string, error) {
 }
 
 // AddCapability adds capability to the provided channel config.
-// If the provided capability already exist in current configuration, this action
+// If the provided capability already exists in current configuration, this action
 // will be a no-op.
 func (o *OrdererGroup) AddCapability(capability string) error {
 	capabilities, err := o.Capabilities()
@@ -551,7 +551,7 @@ func (o *OrdererGroup) RemoveCapability(capability string) error {
 }
 
 // SetEndpoint adds an orderer's endpoint to an existing channel config transaction.
-// If the same endpoint already exist in current configuration, this will be a no-op.
+// If the same endpoint already exists in current configuration, this will be a no-op.
 func (o *OrdererOrg) SetEndpoint(endpoint Address) error {
 	ordererAddrProto := &cb.OrdererAddresses{}
 
@@ -613,7 +613,7 @@ func (o *OrdererOrg) RemoveEndpoint(endpoint Address) error {
 }
 
 // SetPolicy sets the specified policy in the orderer group's config policy map.
-// If the policy already exist in current configuration, its value will be overwritten.
+// If the policy already exists in current configuration, its value will be overwritten.
 func (o *OrdererGroup) SetPolicy(modPolicy, policyName string, policy Policy) error {
 	err := setPolicy(o.ordererGroup, modPolicy, policyName, policy)
 	if err != nil {

--- a/configtx/policies.go
+++ b/configtx/policies.go
@@ -202,6 +202,7 @@ func setPolicies(cg *cb.ConfigGroup, policyMap map[string]Policy, modPolicy stri
 		return errors.New("no Writers policy defined")
 	}
 
+	cg.Policies = make(map[string]*cb.ConfigPolicy)
 	for policyName, policy := range policyMap {
 		err := setPolicy(cg, modPolicy, policyName, policy)
 		if err != nil {


### PR DESCRIPTION
This patch adds SetPolicies() to easily replace multiple policies for groups and orgs in an existing configuration with the given policies.

#### Type of change

- New feature
- Test update

#### Description

This patch adds SetPolicies() to easily replace multiple policies for groups and orgs in an existing configuration with the given policies.

Targets to add the new functions:
- ApplicationGroup
- ApplicationOrg
- ChannelGroup
- ConsortiumOrg
- OrdererGroup
- OrdererOrg

By providing functions to replace multiple policies in bulk, users can change multiple policies with a single function call, so users should not need a tedious method (e.g., repeat SetPolicy() and RemovePolicy() for a group to be replaced).

As preparation for supporting SetPolicies() for groups and orgs, this patch modifies setPolicies() in configtx/policies.go in to clear all existing policies in an existing configuration and then replace them with the given policies.

Also, this patch fixes minor typos in comments.

#### Related issues

- https://jira.hyperledger.org/browse/FAB-18268
