### PR TITLE
[FAB-18099] Validate TLS intermediate certs against TLS root certs

### DIFF
--- a/configtx/msp.go
+++ b/configtx/msp.go
@@ -889,6 +889,7 @@ func (m *MSP) validateCACerts() error {
 	if err != nil {
 		return fmt.Errorf("invalid intermediate cert: %v", err)
 	}
+
 	//TODO: follow the workaround that msp code use to incorporate cert.Verify()
 	for _, ic := range m.IntermediateCerts {
 		validIntermediateCert := false
@@ -912,6 +913,20 @@ func (m *MSP) validateCACerts() error {
 	err = validateCACerts(m.TLSIntermediateCerts)
 	if err != nil {
 		return fmt.Errorf("invalid tls intermediate cert: %v", err)
+	}
+
+	tlsRootPool := x509.NewCertPool()
+	for _, rootCert := range m.TLSRootCerts {
+		tlsRootPool.AddCert(rootCert)
+	}
+
+	for _, ic := range m.TLSIntermediateCerts {
+		_, err := ic.Verify(x509.VerifyOptions{
+			Roots: tlsRootPool,
+		})
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Tiffany Harris <tiffany.harris@ibm.com>

#### Type of change

- New feature

#### Description

validates TLS intermediate certs against the TLS root certs using the x509.Verify()

#### Related issues

[FAB-18099](https://jira.hyperledger.org/browse/FAB-18099)
