### PR TITLE
Added support for mod policies

### DIFF
--- a/configtx/application.go
+++ b/configtx/application.go
@@ -22,6 +22,7 @@ type Application struct {
 	Capabilities  []string
 	Policies      map[string]Policy
 	ACLs          map[string]string
+	ModPolicy     string
 }
 
 // ApplicationGroup encapsulates the part of the config that controls
@@ -176,10 +177,21 @@ func (a *ApplicationGroup) Policies() (map[string]Policy, error) {
 	return getPolicies(a.applicationGroup.Policies)
 }
 
+// SetModPolicy sets the specified modification policy for the application group.
+func (a *ApplicationGroup) SetModPolicy(modPolicy string) error {
+	if modPolicy == "" {
+		return errors.New("non empty mod policy is required")
+	}
+
+	a.applicationGroup.ModPolicy = modPolicy
+
+	return nil
+}
+
 // SetPolicy sets the specified policy in the application group's config policy map.
 // If the policy already exists in current configuration, its value will be overwritten.
-func (a *ApplicationGroup) SetPolicy(modPolicy, policyName string, policy Policy) error {
-	err := setPolicy(a.applicationGroup, modPolicy, policyName, policy)
+func (a *ApplicationGroup) SetPolicy(policyName string, policy Policy) error {
+	err := setPolicy(a.applicationGroup, policyName, policy)
 	if err != nil {
 		return fmt.Errorf("failed to set policy '%s': %v", policyName, err)
 	}
@@ -189,8 +201,8 @@ func (a *ApplicationGroup) SetPolicy(modPolicy, policyName string, policy Policy
 
 // SetPolicies sets the specified policies in the application group's config policy map.
 // If the policies already exist in current configuration, the values will be replaced with new policies.
-func (a *ApplicationGroup) SetPolicies(modPolicy string, policies map[string]Policy) error {
-	err := setPolicies(a.applicationGroup, policies, modPolicy)
+func (a *ApplicationGroup) SetPolicies(policies map[string]Policy) error {
+	err := setPolicies(a.applicationGroup, policies)
 	if err != nil {
 		return fmt.Errorf("failed to set policies: %v", err)
 	}
@@ -216,10 +228,21 @@ func (a *ApplicationOrg) Policies() (map[string]Policy, error) {
 	return getPolicies(a.orgGroup.Policies)
 }
 
+// SetModPolicy sets the specified modification policy for the application organization group.
+func (a *ApplicationOrg) SetModPolicy(modPolicy string) error {
+	if modPolicy == "" {
+		return errors.New("non empty mod policy is required")
+	}
+
+	a.orgGroup.ModPolicy = modPolicy
+
+	return nil
+}
+
 // SetPolicy sets the specified policy in the application org group's config policy map.
 // If an Organization policy already exists in current configuration, its value will be overwritten.
-func (a *ApplicationOrg) SetPolicy(modPolicy, policyName string, policy Policy) error {
-	err := setPolicy(a.orgGroup, modPolicy, policyName, policy)
+func (a *ApplicationOrg) SetPolicy(policyName string, policy Policy) error {
+	err := setPolicy(a.orgGroup, policyName, policy)
 	if err != nil {
 		return fmt.Errorf("failed to set policy '%s': %v", policyName, err)
 	}
@@ -229,8 +252,8 @@ func (a *ApplicationOrg) SetPolicy(modPolicy, policyName string, policy Policy) 
 
 // SetPolicies sets the specified policies in the application org group's config policy map.
 // If the policies already exist in current configuration, the values will be replaced with new policies.
-func (a *ApplicationOrg) SetPolicies(modPolicy string, policies map[string]Policy) error {
-	err := setPolicies(a.orgGroup, policies, modPolicy)
+func (a *ApplicationOrg) SetPolicies(policies map[string]Policy) error {
+	err := setPolicies(a.orgGroup, policies)
 	if err != nil {
 		return fmt.Errorf("failed to set policies: %v", err)
 	}
@@ -458,7 +481,11 @@ func newApplicationGroupTemplate(application Application) (*cb.ConfigGroup, erro
 	applicationGroup := newConfigGroup()
 	applicationGroup.ModPolicy = AdminsPolicyKey
 
-	if err = setPolicies(applicationGroup, application.Policies, AdminsPolicyKey); err != nil {
+	if application.ModPolicy != "" {
+		applicationGroup.ModPolicy = application.ModPolicy
+	}
+
+	if err = setPolicies(applicationGroup, application.Policies); err != nil {
 		return nil, err
 	}
 

--- a/configtx/channel.go
+++ b/configtx/channel.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package configtx
 
 import (
+	"errors"
 	"fmt"
 
 	cb "github.com/hyperledger/fabric-protos-go/common"
@@ -83,16 +84,27 @@ func (c *ChannelGroup) Policies() (map[string]Policy, error) {
 	return getPolicies(c.channelGroup.Policies)
 }
 
+// SetModPolicy sets the specified modification policy for the channel group.
+func (c *ChannelGroup) SetModPolicy(modPolicy string) error {
+	if modPolicy == "" {
+		return errors.New("non empty mod policy is required")
+	}
+
+	c.channelGroup.ModPolicy = modPolicy
+
+	return nil
+}
+
 // SetPolicy sets the specified policy in the channel group's config policy map.
 // If the policy already exists in current configuration, its value will be overwritten.
-func (c *ChannelGroup) SetPolicy(modPolicy, policyName string, policy Policy) error {
-	return setPolicy(c.channelGroup, modPolicy, policyName, policy)
+func (c *ChannelGroup) SetPolicy(policyName string, policy Policy) error {
+	return setPolicy(c.channelGroup, policyName, policy)
 }
 
 // SetPolicies sets the specified policies in the channel group's config policy map.
 // If the policies already exist in current configuration, the values will be replaced with new policies.
-func (c *ChannelGroup) SetPolicies(modPolicy string, policies map[string]Policy) error {
-	return setPolicies(c.channelGroup, policies, modPolicy)
+func (c *ChannelGroup) SetPolicies(policies map[string]Policy) error {
+	return setPolicies(c.channelGroup, policies)
 }
 
 // RemovePolicy removes an existing channel level policy.

--- a/configtx/config.go
+++ b/configtx/config.go
@@ -39,12 +39,14 @@ type Channel struct {
 	Consortiums  []Consortium
 	Capabilities []string
 	Policies     map[string]Policy
+	ModPolicy    string
 }
 
 // Policy is an expression used to define rules for access to channels, chaincodes, etc.
 type Policy struct {
-	Type string
-	Rule string
+	Type      string
+	Rule      string
+	ModPolicy string
 }
 
 // Organization is an organization in the channel configuration.
@@ -57,6 +59,7 @@ type Organization struct {
 	// application organization.
 	AnchorPeers      []Address
 	OrdererEndpoints []string
+	ModPolicy        string
 }
 
 // Address contains the hostname and port for an endpoint.
@@ -227,6 +230,10 @@ func newSystemChannelGroup(channelConfig Channel) (*cb.ConfigGroup, error) {
 
 	channelGroup.ModPolicy = AdminsPolicyKey
 
+	if channelConfig.ModPolicy != "" {
+		channelGroup.ModPolicy = channelConfig.ModPolicy
+	}
+
 	return channelGroup, nil
 }
 
@@ -247,13 +254,17 @@ func newApplicationChannelGroup(channelConfig Channel) (*cb.ConfigGroup, error) 
 
 	channelGroup.ModPolicy = AdminsPolicyKey
 
+	if channelConfig.ModPolicy != "" {
+		channelGroup.ModPolicy = channelConfig.ModPolicy
+	}
+
 	return channelGroup, nil
 }
 
 func newChannelGroupWithOrderer(channelConfig Channel) (*cb.ConfigGroup, error) {
 	channelGroup := newConfigGroup()
 
-	err := setPolicies(channelGroup, channelConfig.Policies, AdminsPolicyKey)
+	err := setPolicies(channelGroup, channelConfig.Policies)
 	if err != nil {
 		return nil, fmt.Errorf("setting channel policies: %v", err)
 	}
@@ -435,6 +446,10 @@ func newChannelGroup(channelConfig Channel) (*cb.ConfigGroup, error) {
 	}
 
 	channelGroup.ModPolicy = AdminsPolicyKey
+
+	if channelConfig.ModPolicy != "" {
+		channelGroup.ModPolicy = channelConfig.ModPolicy
+	}
 
 	return channelGroup, nil
 }

--- a/configtx/config_test.go
+++ b/configtx/config_test.go
@@ -2060,7 +2060,7 @@ func TestChannelConfiguration(t *testing.T) {
 					applicationGroup.Groups[org.Name] = orgGroup
 				}
 				channelGroup.Groups[ApplicationGroupKey] = applicationGroup
-				err = setPolicies(channelGroup, standardPolicies(), AdminsPolicyKey)
+				err = setPolicies(channelGroup, standardPolicies())
 				gt.Expect(err).NotTo(HaveOccurred())
 
 				return &cb.Config{
@@ -2081,6 +2081,7 @@ func TestChannelConfiguration(t *testing.T) {
 					Capabilities: []string{"V2_0"},
 					Policies:     policies,
 					Consortium:   "testconsortium",
+					ModPolicy:    AdminsPolicyKey,
 				}
 				channelGroup, err := newSystemChannelGroup(channel)
 				gt.Expect(err).NotTo(HaveOccurred())
@@ -2150,22 +2151,26 @@ func baseApplicationChannelProfile(t *testing.T) (Channel, []*ecdsa.PrivateKey, 
 		Orderer:      orderer,
 		Capabilities: []string{"V2_0"},
 		Policies:     standardPolicies(),
+		ModPolicy:    AdminsPolicyKey,
 	}, applicationPrivKey, ordererPrivKeys[0]
 }
 
 func standardPolicies() map[string]Policy {
 	return map[string]Policy{
 		ReadersPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "ANY Readers",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "ANY Readers",
+			ModPolicy: AdminsPolicyKey,
 		},
 		WritersPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "ANY Writers",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "ANY Writers",
+			ModPolicy: AdminsPolicyKey,
 		},
 		AdminsPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "MAJORITY Admins",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "MAJORITY Admins",
+			ModPolicy: AdminsPolicyKey,
 		},
 	}
 }
@@ -2174,8 +2179,9 @@ func orgStandardPolicies() map[string]Policy {
 	policies := standardPolicies()
 
 	policies[EndorsementPolicyKey] = Policy{
-		Type: ImplicitMetaPolicyType,
-		Rule: "MAJORITY Endorsement",
+		Type:      ImplicitMetaPolicyType,
+		Rule:      "MAJORITY Endorsement",
+		ModPolicy: AdminsPolicyKey,
 	}
 
 	return policies
@@ -2185,8 +2191,9 @@ func applicationOrgStandardPolicies() map[string]Policy {
 	policies := orgStandardPolicies()
 
 	policies[LifecycleEndorsementPolicyKey] = Policy{
-		Type: ImplicitMetaPolicyType,
-		Rule: "MAJORITY Endorsement",
+		Type:      ImplicitMetaPolicyType,
+		Rule:      "MAJORITY Endorsement",
+		ModPolicy: AdminsPolicyKey,
 	}
 
 	return policies
@@ -2196,8 +2203,9 @@ func ordererStandardPolicies() map[string]Policy {
 	policies := standardPolicies()
 
 	policies[BlockValidationPolicyKey] = Policy{
-		Type: ImplicitMetaPolicyType,
-		Rule: "ANY Writers",
+		Type:      ImplicitMetaPolicyType,
+		Rule:      "ANY Writers",
+		ModPolicy: AdminsPolicyKey,
 	}
 
 	return policies

--- a/configtx/consortiums.go
+++ b/configtx/consortiums.go
@@ -229,10 +229,21 @@ func (c *ConsortiumOrg) Policies() (map[string]Policy, error) {
 	return getPolicies(c.orgGroup.Policies)
 }
 
+// SetModPolicy sets the specified modification policy for the consortium org group.
+func (c *ConsortiumOrg) SetModPolicy(modPolicy string) error {
+	if modPolicy == "" {
+		return errors.New("non empty mod policy is required")
+	}
+
+	c.orgGroup.ModPolicy = modPolicy
+
+	return nil
+}
+
 // SetPolicy sets the specified policy in the consortium org group's config policy map.
 // If the policy already exists in current configuration, its value will be overwritten.
 func (c *ConsortiumOrg) SetPolicy(name string, policy Policy) error {
-	err := setPolicy(c.orgGroup, AdminsPolicyKey, name, policy)
+	err := setPolicy(c.orgGroup, name, policy)
 	if err != nil {
 		return fmt.Errorf("failed to set policy '%s' to consortium org '%s': %v", name, c.name, err)
 	}
@@ -243,7 +254,7 @@ func (c *ConsortiumOrg) SetPolicy(name string, policy Policy) error {
 // SetPolicies sets the specified policies in the consortium org group's config policy map.
 // If the policies already exist in current configuration, the values will be replaced with new policies.
 func (c *ConsortiumOrg) SetPolicies(policies map[string]Policy) error {
-	err := setPolicies(c.orgGroup, policies, AdminsPolicyKey)
+	err := setPolicies(c.orgGroup, policies)
 	if err != nil {
 		return fmt.Errorf("failed to set policies to consortium org '%s': %v", c.name, err)
 	}

--- a/configtx/consortiums_test.go
+++ b/configtx/consortiums_test.go
@@ -1486,6 +1486,56 @@ func TestRemoveConsortiumOrg(t *testing.T) {
 	gt.Expect(c.Consortium("Consortium1").Organization("Org1")).To(BeNil())
 }
 
+func TestSetConsortiumOrgModPolicy(t *testing.T) {
+	t.Parallel()
+
+	gt := NewGomegaWithT(t)
+
+	consortiums, _ := baseConsortiums(t)
+	consortiumsGroup, err := newConsortiumsGroup(consortiums)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	config := &cb.Config{
+		ChannelGroup: &cb.ConfigGroup{
+			Groups: map[string]*cb.ConfigGroup{
+				ConsortiumsGroupKey: consortiumsGroup,
+			},
+		},
+	}
+
+	c := New(config)
+
+	consortium1Org1 := c.Consortium("Consortium1").Organization("Org1")
+	err = consortium1Org1.SetModPolicy("TestModPolicy")
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	updatedModPolicy := consortium1Org1.orgGroup.GetModPolicy()
+	gt.Expect(updatedModPolicy).To(Equal("TestModPolicy"))
+}
+
+func TestSetConsortiumOrgModPolicyFailures(t *testing.T) {
+	t.Parallel()
+
+	gt := NewGomegaWithT(t)
+
+	consortiums, _ := baseConsortiums(t)
+	consortiumsGroup, err := newConsortiumsGroup(consortiums)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	config := &cb.Config{
+		ChannelGroup: &cb.ConfigGroup{
+			Groups: map[string]*cb.ConfigGroup{
+				ConsortiumsGroupKey: consortiumsGroup,
+			},
+		},
+	}
+
+	c := New(config)
+
+	err = c.Consortium("Consortium1").Organization("Org1").SetModPolicy("")
+	gt.Expect(err).To(MatchError("non empty mod policy is required"))
+}
+
 func TestSetConsortiumOrgPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -1508,24 +1558,29 @@ func TestSetConsortiumOrgPolicy(t *testing.T) {
 
 	expectedPolicies := map[string]Policy{
 		ReadersPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "ANY Readers",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "ANY Readers",
+			ModPolicy: AdminsPolicyKey,
 		},
 		WritersPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "ANY Writers",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "ANY Writers",
+			ModPolicy: AdminsPolicyKey,
 		},
 		AdminsPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "MAJORITY Admins",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "MAJORITY Admins",
+			ModPolicy: AdminsPolicyKey,
 		},
 		EndorsementPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "MAJORITY Endorsement",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "MAJORITY Endorsement",
+			ModPolicy: AdminsPolicyKey,
 		},
 		"TestPolicy": {
-			Type: ImplicitMetaPolicyType,
-			Rule: "MAJORITY Endorsement",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "MAJORITY Endorsement",
+			ModPolicy: AdminsPolicyKey,
 		},
 	}
 
@@ -1601,28 +1656,34 @@ func TestSetConsortiumOrgPolicies(t *testing.T) {
 
 	newPolicies := map[string]Policy{
 		ReadersPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "ANY Readers",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "ANY Readers",
+			ModPolicy: AdminsPolicyKey,
 		},
 		WritersPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "ANY Writers",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "ANY Writers",
+			ModPolicy: AdminsPolicyKey,
 		},
 		AdminsPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "MAJORITY Admins",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "MAJORITY Admins",
+			ModPolicy: AdminsPolicyKey,
 		},
 		EndorsementPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "MAJORITY Endorsement",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "MAJORITY Endorsement",
+			ModPolicy: AdminsPolicyKey,
 		},
 		"TestPolicy_Add1": {
-			Type: ImplicitMetaPolicyType,
-			Rule: "MAJORITY Endorsement",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "MAJORITY Endorsement",
+			ModPolicy: AdminsPolicyKey,
 		},
 		"TestPolicy_Add2": {
-			Type: ImplicitMetaPolicyType,
-			Rule: "MAJORITY Endorsement",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "MAJORITY Endorsement",
+			ModPolicy: AdminsPolicyKey,
 		},
 	}
 
@@ -1704,20 +1765,24 @@ func TestRemoveConsortiumOrgPolicy(t *testing.T) {
 
 	expectedPolicies := map[string]Policy{
 		ReadersPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "ANY Readers",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "ANY Readers",
+			ModPolicy: AdminsPolicyKey,
 		},
 		WritersPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "ANY Writers",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "ANY Writers",
+			ModPolicy: AdminsPolicyKey,
 		},
 		AdminsPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "MAJORITY Admins",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "MAJORITY Admins",
+			ModPolicy: AdminsPolicyKey,
 		},
 		EndorsementPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "MAJORITY Endorsement",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "MAJORITY Endorsement",
+			ModPolicy: AdminsPolicyKey,
 		},
 	}
 
@@ -1751,20 +1816,24 @@ func TestConsortiumOrgPolicies(t *testing.T) {
 
 	expectedPolicies := map[string]Policy{
 		ReadersPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "ANY Readers",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "ANY Readers",
+			ModPolicy: AdminsPolicyKey,
 		},
 		WritersPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "ANY Writers",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "ANY Writers",
+			ModPolicy: AdminsPolicyKey,
 		},
 		AdminsPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "MAJORITY Admins",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "MAJORITY Admins",
+			ModPolicy: AdminsPolicyKey,
 		},
 		EndorsementPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "MAJORITY Endorsement",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "MAJORITY Endorsement",
+			ModPolicy: AdminsPolicyKey,
 		},
 	}
 

--- a/configtx/example_test.go
+++ b/configtx/example_test.go
@@ -220,7 +220,6 @@ func Example_policies() {
 	applicationOrg1 := c.Application().Organization("Org1")
 
 	err := applicationOrg1.SetPolicy(
-		configtx.AdminsPolicyKey,
 		"TestPolicy",
 		configtx.Policy{
 			Type: configtx.ImplicitMetaPolicyType,
@@ -244,7 +243,6 @@ func Example_policies() {
 	}
 
 	err = ordererOrg.SetPolicy(
-		configtx.AdminsPolicyKey,
 		"TestPolicy",
 		configtx.Policy{
 			Type: configtx.ImplicitMetaPolicyType,
@@ -259,7 +257,7 @@ func Example_policies() {
 		panic(err)
 	}
 
-	err = o.SetPolicy(configtx.AdminsPolicyKey, "TestPolicy", configtx.Policy{
+	err = o.SetPolicy("TestPolicy", configtx.Policy{
 		Type: configtx.ImplicitMetaPolicyType,
 		Rule: "MAJORITY Endorsement",
 	})
@@ -305,7 +303,7 @@ func Example_policies2() {
 			Rule: "MAJORITY Admins",
 		},
 	}
-	err := a.SetPolicies(configtx.AdminsPolicyKey, newAppPolicies)
+	err := a.SetPolicies(newAppPolicies)
 	if err != nil {
 		panic(err)
 	}
@@ -337,7 +335,7 @@ func Example_policies2() {
 			Rule: "MAJORITY Writers",
 		},
 	}
-	err = o.SetPolicies(configtx.AdminsPolicyKey, newOrdererPolicies)
+	err = o.SetPolicies(newOrdererPolicies)
 	if err != nil {
 		panic(err)
 	}

--- a/configtx/orderer.go
+++ b/configtx/orderer.go
@@ -44,7 +44,8 @@ type Orderer struct {
 	Capabilities []string
 	Policies     map[string]Policy
 	// Options: `ConsensusStateNormal` and `ConsensusStateMaintenance`
-	State orderer.ConsensusState
+	State     orderer.ConsensusState
+	ModPolicy string
 }
 
 // OrdererGroup encapsulates the parts of the config that control
@@ -198,6 +199,7 @@ func (o *OrdererGroup) Configuration() (Orderer, error) {
 		Capabilities:  capabilities,
 		Policies:      policies,
 		State:         state,
+		ModPolicy:     o.ordererGroup.GetModPolicy(),
 	}, nil
 }
 
@@ -612,10 +614,21 @@ func (o *OrdererOrg) RemoveEndpoint(endpoint Address) error {
 	return nil
 }
 
+// SetModPolicy sets the specified modification policy for the orderer group.
+func (o *OrdererGroup) SetModPolicy(modPolicy string) error {
+	if modPolicy == "" {
+		return errors.New("non empty mod policy is required")
+	}
+
+	o.ordererGroup.ModPolicy = modPolicy
+
+	return nil
+}
+
 // SetPolicy sets the specified policy in the orderer group's config policy map.
 // If the policy already exists in current configuration, its value will be overwritten.
-func (o *OrdererGroup) SetPolicy(modPolicy, policyName string, policy Policy) error {
-	err := setPolicy(o.ordererGroup, modPolicy, policyName, policy)
+func (o *OrdererGroup) SetPolicy(policyName string, policy Policy) error {
+	err := setPolicy(o.ordererGroup, policyName, policy)
 	if err != nil {
 		return fmt.Errorf("failed to set policy '%s': %v", policyName, err)
 	}
@@ -625,13 +638,13 @@ func (o *OrdererGroup) SetPolicy(modPolicy, policyName string, policy Policy) er
 
 // SetPolicies sets the specified policy in the orderer group's config policy map.
 // If the policies already exist in current configuration, the values will be replaced with new policies.
-func (o *OrdererGroup) SetPolicies(modPolicy string, policies map[string]Policy) error {
+func (o *OrdererGroup) SetPolicies(policies map[string]Policy) error {
 
 	if _, ok := policies[BlockValidationPolicyKey]; !ok {
 		return errors.New("BlockValidation policy must be defined")
 	}
 
-	err := setPolicies(o.ordererGroup, policies, modPolicy)
+	err := setPolicies(o.ordererGroup, policies)
 	if err != nil {
 		return fmt.Errorf("failed to set policies: %v", err)
 	}
@@ -685,16 +698,27 @@ func (o *OrdererOrg) SetMSP(updatedMSP MSP) error {
 	return nil
 }
 
+// SetModPolicy sets the specified modification policy for the orderer org group.
+func (o *OrdererOrg) SetModPolicy(modPolicy string) error {
+	if modPolicy == "" {
+		return errors.New("non empty mod policy is required")
+	}
+
+	o.orgGroup.ModPolicy = modPolicy
+
+	return nil
+}
+
 // SetPolicy sets the specified policy in the orderer org group's config policy map.
 // If the policy already exists in current configuration, its value will be overwritten.
-func (o *OrdererOrg) SetPolicy(modPolicy, policyName string, policy Policy) error {
-	return setPolicy(o.orgGroup, modPolicy, policyName, policy)
+func (o *OrdererOrg) SetPolicy(policyName string, policy Policy) error {
+	return setPolicy(o.orgGroup, policyName, policy)
 }
 
 // SetPolicies sets the specified policies in the orderer org group's config policy map.
 // If the policies already exist in current configuration, the values will be replaced with new policies.
-func (o *OrdererOrg) SetPolicies(modPolicy string, policies map[string]Policy) error {
-	return setPolicies(o.orgGroup, policies, modPolicy)
+func (o *OrdererOrg) SetPolicies(policies map[string]Policy) error {
+	return setPolicies(o.orgGroup, policies)
 }
 
 // RemovePolicy removes an existing policy from an orderer organization.
@@ -728,6 +752,10 @@ func (o *OrdererGroup) RemoveLegacyKafkaBrokers() {
 func newOrdererGroup(orderer Orderer) (*cb.ConfigGroup, error) {
 	ordererGroup := newConfigGroup()
 	ordererGroup.ModPolicy = AdminsPolicyKey
+
+	if orderer.ModPolicy != "" {
+		ordererGroup.ModPolicy = orderer.ModPolicy
+	}
 
 	if err := setOrdererPolicies(ordererGroup, orderer.Policies, AdminsPolicyKey); err != nil {
 		return nil, err
@@ -824,7 +852,7 @@ func setOrdererPolicies(cg *cb.ConfigGroup, policyMap map[string]Policy, modPoli
 		return errors.New("no BlockValidation policy defined")
 	}
 
-	return setPolicies(cg, policyMap, modPolicy)
+	return setPolicies(cg, policyMap)
 }
 
 // batchSizeValue returns the config definition for the orderer batch size.

--- a/configtx/organization.go
+++ b/configtx/organization.go
@@ -22,7 +22,11 @@ func newOrgConfigGroup(org Organization) (*cb.ConfigGroup, error) {
 	orgGroup := newConfigGroup()
 	orgGroup.ModPolicy = AdminsPolicyKey
 
-	if err := setPolicies(orgGroup, org.Policies, AdminsPolicyKey); err != nil {
+	if org.ModPolicy != "" {
+		orgGroup.ModPolicy = org.ModPolicy
+	}
+
+	if err := setPolicies(orgGroup, org.Policies); err != nil {
 		return nil, err
 	}
 

--- a/configtx/policies_test.go
+++ b/configtx/policies_test.go
@@ -20,24 +20,28 @@ func TestPolicies(t *testing.T) {
 
 	expectedPolicies := map[string]Policy{
 		ReadersPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "ALL Member",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "ALL Member",
+			ModPolicy: AdminsPolicyKey,
 		},
 		WritersPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "ANY Member",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "ANY Member",
+			ModPolicy: AdminsPolicyKey,
 		},
 		AdminsPolicyKey: {
-			Type: ImplicitMetaPolicyType,
-			Rule: "MAJORITY Member",
+			Type:      ImplicitMetaPolicyType,
+			Rule:      "MAJORITY Member",
+			ModPolicy: AdminsPolicyKey,
 		},
 		"SignaturePolicy": {
-			Type: SignaturePolicyType,
-			Rule: "AND('Org1.member', 'Org2.client', OR('Org3.peer', 'Org3.admin'), OUTOF(2, 'Org4.member', 'Org4.peer', 'Org4.admin'))",
+			Type:      SignaturePolicyType,
+			Rule:      "AND('Org1.member', 'Org2.client', OR('Org3.peer', 'Org3.admin'), OUTOF(2, 'Org4.member', 'Org4.peer', 'Org4.admin'))",
+			ModPolicy: AdminsPolicyKey,
 		},
 	}
 	orgGroup := newConfigGroup()
-	err := setPolicies(orgGroup, expectedPolicies, AdminsPolicyKey)
+	err := setPolicies(orgGroup, expectedPolicies)
 	gt.Expect(err).NotTo(HaveOccurred())
 
 	policies, err := getPolicies(orgGroup.Policies)


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Added support for mod policies in config groups: Application, ApplicationOrg, Channel, ConsortiumOrg, Orderer, OrdererOrg. Previous implementation wasn't able to set mod policies which is beneficial when creating production grade custom channel configurations.

#### Additional details

The previous code was setting mod policies to `AdminModPolicyKey` by default. This behavior was retained so when the mod policy is not set manually it is automatically set to `AdminModPolicyKey`.

There are two incompatible changes in methods `SetPolicy` and `SetPolicies` which omit first parameter called `modPolicy` because it's not needed anymore. There is a new field `ModPolicy` in `Policy` struct instead of it.

Those changes were tested in a production grade Fabric environment.