### PR TITLE
Remove a return statement to be able to add more than one peer in the existingAnchorPeers array

### DIFF
--- a/configtx/application.go
+++ b/configtx/application.go
@@ -360,8 +360,6 @@ func (a *ApplicationOrg) RemoveAnchorPeer(anchorPeerToRemove Address) error {
 			if err != nil {
 				return fmt.Errorf("failed to remove anchor peer %v from org %s: %v", anchorPeerToRemove, a.name, err)
 			}
-
-			return nil
 		}
 	}
 


### PR DESCRIPTION
Resolves #49 If the node has more than one anchor peer, it will return before all existent peers have been added again to existingAnchorPeers

Signed-off-by: Ernesto Olivier <ernesto.olivier@nexplore.com>

#### Type of change

- Bug fix

#### Description

When the RemoveAnchorPeer function is called, it just loops over the Anchor Peers and compare it with the one that it is requested to be deleted, if the current doesn't match it is added again to the config using a new array called existingAnchorPeers. 

So far so good but then there is a return statement inside the loop that it is preventing to add more than one Peer to existingAnchorPeers array.

This PR just remove that return to enable to fill the existingAnchorPeers array with all remaining Anchor Peers.

My motivation is basically that I am using this function and is not working properly so I created a workaround in my code while this bug is fixed.  

#### Related issues

[This PR resolves issue 49](https://github.com/hyperledger/fabric-config/issues/49)



