### PR TITLE
remove kafka and fix tests

### DIFF
--- a/configtx/orderer.go
+++ b/configtx/orderer.go
@@ -816,10 +816,7 @@ func addOrdererValues(ordererGroup *cb.ConfigGroup, o Orderer) error {
 	switch o.OrdererType {
 	case orderer.ConsensusTypeSolo:
 	case orderer.ConsensusTypeKafka:
-		err = setValue(ordererGroup, kafkaBrokersValue(o.Kafka.Brokers), AdminsPolicyKey)
-		if err != nil {
-			return err
-		}
+		return fmt.Errorf("the kafka consensus type is no longer supported")
 	case orderer.ConsensusTypeEtcdRaft:
 		if consensusMetadata, err = marshalEtcdRaftMetadata(o.EtcdRaft); err != nil {
 			return fmt.Errorf("marshaling etcdraft metadata for orderer type '%s': %v", orderer.ConsensusTypeEtcdRaft, err)
@@ -902,6 +899,7 @@ func channelRestrictionsValue(maxChannelCount uint64) *standardConfigValue {
 
 // kafkaBrokersValue returns the config definition for the addresses of the ordering service's Kafka brokers.
 // It is a value for the /Channel/Orderer group.
+// Deprecated: the kafka consensus type is no longer supported
 func kafkaBrokersValue(brokers []string) *standardConfigValue {
 	return &standardConfigValue{
 		key: orderer.KafkaBrokersKey,

--- a/configtx/orderer/orderer.go
+++ b/configtx/orderer/orderer.go
@@ -22,12 +22,14 @@ const (
 	ConsensusTypeSolo = "solo"
 
 	// ConsensusTypeKafka identifies the Kafka-based consensus implementation.
+	// Deprecated: the kafka consensus type is no longer supported
 	ConsensusTypeKafka = "kafka"
 
 	// ConsensusTypeEtcdRaft identifies the Raft-based consensus implementation.
 	ConsensusTypeEtcdRaft = "etcdraft"
 
 	// KafkaBrokersKey is the common.ConfigValue type key name for the KafkaBrokers message.
+	// Deprecated: the kafka consensus type is no longer supported
 	KafkaBrokersKey = "KafkaBrokers"
 
 	// ConsensusTypeKey is the common.ConfigValue type key name for the ConsensusType message.
@@ -58,6 +60,7 @@ type BatchSize struct {
 }
 
 // Kafka is a list of Kafka broker endpoints.
+// Deprecated: the kafka consensus type is no longer supported
 type Kafka struct {
 	// Brokers contains the addresses of *at least two* kafka brokers
 	// Must be in `IP:port` notation


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update


#### Description

I removed Kafka as it is not supported as a consensus type, by mark as a deprecated Kafka's fields and functions. I also blocked the option to add configuration to an orderer with Kafka as a consensus type.
I fixed tests that had a bug and tests that need to fit to our new requirements.

#### Related issues

 issue #3513 in Fabric
