### PR TITLE
Add support for ConsensusTypeBFT in the orderer.go

### DIFF
--- a/configtx/orderer/orderer.go
+++ b/configtx/orderer/orderer.go
@@ -28,6 +28,9 @@ const (
 	// ConsensusTypeEtcdRaft identifies the Raft-based consensus implementation.
 	ConsensusTypeEtcdRaft = "etcdraft"
 
+	// ConsensusTypeBFT identifies the SmartBFT-based consensus implementation.
+	ConsensusTypeBFT = "BFT"
+
 	// KafkaBrokersKey is the common.ConfigValue type key name for the KafkaBrokers message.
 	// Deprecated: the kafka consensus type is no longer supported
 	KafkaBrokersKey = "KafkaBrokers"


### PR DESCRIPTION

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->


- New feature

#### Description

Add support for ConsensusTypeBFT in the orderer to be able to use this library to create the channel configuration using golang.

#### Additional details

None

#### Related issues

No related issues

