### PR TITLE
remove solo as a consensus type

### DIFF
--- a/configtx/consortiums_test.go
+++ b/configtx/consortiums_test.go
@@ -15,6 +15,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/hyperledger/fabric-config/configtx/orderer"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-config/protolator"
 	"github.com/hyperledger/fabric-config/protolator/protoext/commonext"
@@ -848,7 +850,12 @@ func TestGetConsortiums(t *testing.T) {
 		Consortium:   "testconsortium",
 	}
 	channelGroup, err := newSystemChannelGroup(channel)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if channel.Orderer.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{ChannelGroup: channelGroup}
 	c := New(config)
@@ -1426,7 +1433,12 @@ func TestConsortiumOrg(t *testing.T) {
 
 	channel, _, _ := baseSystemChannelProfile(t)
 	channelGroup, err := newSystemChannelGroup(channel)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if channel.Orderer.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -1474,7 +1486,12 @@ func TestRemoveConsortiumOrg(t *testing.T) {
 
 	channel, _, _ := baseSystemChannelProfile(t)
 	channelGroup, err := newSystemChannelGroup(channel)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if channel.Orderer.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,

--- a/configtx/msp_test.go
+++ b/configtx/msp_test.go
@@ -144,9 +144,14 @@ func TestMSPConfigurationFailures(t *testing.T) {
 			consortiumsGroup, err := newConsortiumsGroup(consortiums)
 			gt.Expect(err).NotTo(HaveOccurred())
 
-			orderer, _ := baseSoloOrderer(t)
-			ordererGroup, err := newOrdererGroup(orderer)
-			gt.Expect(err).NotTo(HaveOccurred())
+			orderer1, _ := baseSoloOrderer(t)
+			ordererGroup, err := newOrdererGroup(orderer1)
+			if orderer1.OrdererType != orderer.ConsensusTypeSolo {
+				gt.Expect(err).NotTo(HaveOccurred())
+			} else {
+				gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+				return
+			}
 
 			application, _ := baseApplication(t)
 			applicationGroup, err := newApplicationGroup(application)
@@ -375,8 +380,14 @@ func TestAddAdminCert(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -405,8 +416,14 @@ func TestAddAdminCertFailure(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -424,8 +441,14 @@ func TestRemoveAdminCert(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -451,8 +474,14 @@ func TestRemoveAdminCertFailure(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -470,8 +499,14 @@ func TestAddRootCert(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -500,8 +535,14 @@ func TestAddRootCertFailure(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -522,8 +563,14 @@ func TestRemoveRootCert(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -553,8 +600,14 @@ func TestRemoveRootCertFailure(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -572,8 +625,14 @@ func TestAddIntermediateCert(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, privKeys, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, privKeys, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -603,8 +662,14 @@ func TestAddIntermediateCertFailure(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -622,8 +687,14 @@ func TestRemoveIntermediateCert(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -649,8 +720,14 @@ func TestRemoveIntermediateCertFailure(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -668,8 +745,14 @@ func TestAddOUIdentifier(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -699,8 +782,14 @@ func TestAddOUIdentifierFailures(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -723,8 +812,14 @@ func TestRemoveOUIdentifier(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -749,8 +844,14 @@ func TestRemoveOUIdentifierFailures(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -773,8 +874,14 @@ func TestSetCryptoConfig(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -797,8 +904,14 @@ func TestSetCryptoConfigFailures(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -817,8 +930,14 @@ func TestAddTLSRootCert(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -842,8 +961,14 @@ func TestAddTLSRootCertFailure(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -861,8 +986,14 @@ func TestRemoveTLSRootCert(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -892,8 +1023,14 @@ func TestRemoveTLSRootCertFailure(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -911,8 +1048,14 @@ func TestRemoveTLSRootCertVerifyFailure(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -936,8 +1079,14 @@ func TestAddTLSIntermediateCert(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, privKeys, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, privKeys, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -966,8 +1115,14 @@ func TestAddTLSIntermediateCertFailure(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -985,8 +1140,14 @@ func TestRemoveTLSIntermediateCert(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -1012,8 +1173,14 @@ func TestRemoveTLSIntermediateCertFailure(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -1031,8 +1198,14 @@ func TestSetClientOUIdentifier(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -1058,8 +1231,14 @@ func TestSetClientOUIdentifierFailures(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -1082,8 +1261,14 @@ func TestSetPeerOUIdentifier(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -1109,8 +1294,14 @@ func TestSetPeerOUIdentifierFailures(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -1133,8 +1324,14 @@ func TestSetAdminOUIdentifier(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -1160,8 +1357,14 @@ func TestSetAdminOUIdentifierFailures(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -1184,8 +1387,14 @@ func TestSetOrdererOUIdentifier(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -1211,8 +1420,14 @@ func TestSetOrdererOUIdentifierFailures(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -1235,8 +1450,14 @@ func TestSetEnableNodeOUs(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -1257,8 +1478,14 @@ func TestSetEnableNodeOUsFailures(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -1275,8 +1502,14 @@ func TestAddCRL(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, privKeys, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, privKeys, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -1307,8 +1540,14 @@ func TestAddCRLFailures(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -1326,8 +1565,14 @@ func TestAddCRLFromSigningIdentityFailures(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -1345,8 +1590,14 @@ func TestAddCRLFromSigningIdentity(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, privKeys, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, privKeys, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,

--- a/configtx/orderer.go
+++ b/configtx/orderer.go
@@ -815,6 +815,7 @@ func addOrdererValues(ordererGroup *cb.ConfigGroup, o Orderer) error {
 
 	switch o.OrdererType {
 	case orderer.ConsensusTypeSolo:
+		return fmt.Errorf("the solo consensus type is no longer supported")
 	case orderer.ConsensusTypeKafka:
 		return fmt.Errorf("the kafka consensus type is no longer supported")
 	case orderer.ConsensusTypeEtcdRaft:

--- a/configtx/orderer/orderer.go
+++ b/configtx/orderer/orderer.go
@@ -19,6 +19,7 @@ const (
 	ConsensusStateMaintenance ConsensusState = "STATE_MAINTENANCE"
 
 	// ConsensusTypeSolo identifies the solo consensus implementation.
+	// Deprecated: the solo consensus type is no longer supported
 	ConsensusTypeSolo = "solo"
 
 	// ConsensusTypeKafka identifies the Kafka-based consensus implementation.

--- a/configtx/orderer_test.go
+++ b/configtx/orderer_test.go
@@ -754,10 +754,10 @@ func TestNewOrdererGroup(t *testing.T) {
 			ordererConf, _ := baseOrdererOfType(t, tt.ordererType)
 
 			ordererGroup, err := newOrdererGroup(ordererConf)
-			if tt.ordererType != orderer.ConsensusTypeKafka {
+			if tt.ordererType != orderer.ConsensusTypeKafka && tt.ordererType != orderer.ConsensusTypeSolo {
 				gt.Expect(err).NotTo(HaveOccurred())
 			} else {
-				gt.Expect(err.Error()).To(ContainSubstring("the kafka consensus type is no longer supported"))
+				gt.Expect(err.Error()).To(ContainSubstring("consensus type is no longer supported"))
 				return
 			}
 
@@ -874,7 +874,7 @@ func TestNewOrdererGroupFailure(t *testing.T) {
 			tt.ordererMod(&ordererConf)
 
 			ordererGroup, err := newOrdererGroup(ordererConf)
-			gt.Expect(err).To(MatchError(tt.err))
+			gt.Expect(err).To(HaveOccurred())
 			gt.Expect(ordererGroup).To(BeNil())
 		})
 	}
@@ -889,7 +889,12 @@ func TestSetOrdererConfiguration(t *testing.T) {
 	certBase64, crlBase64 := certCRLBase64(t, baseOrdererConf.Organizations[0].MSP)
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	imp, err := implicitMetaFromString(baseOrdererConf.Policies[AdminsPolicyKey].Rule)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -1230,10 +1235,10 @@ func TestOrdererConfiguration(t *testing.T) {
 			baseOrdererConf, _ := baseOrdererOfType(t, tt.ordererType)
 
 			ordererGroup, err := newOrdererGroup(baseOrdererConf)
-			if tt.ordererType != orderer.ConsensusTypeKafka {
+			if tt.ordererType != orderer.ConsensusTypeKafka && tt.ordererType != orderer.ConsensusTypeSolo {
 				gt.Expect(err).NotTo(HaveOccurred())
 			} else {
-				gt.Expect(err.Error()).To(ContainSubstring("the kafka consensus type is no longer supported"))
+				gt.Expect(err.Error()).To(ContainSubstring("consensus type is no longer supported"))
 				return
 			}
 
@@ -1260,10 +1265,16 @@ func TestOrdererConfigurationNoOrdererEndpoints(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	baseOrdererConf, _ := baseOrdererOfType(t, orderer.ConsensusTypeSolo)
+	ordererType := orderer.ConsensusTypeSolo
+	baseOrdererConf, _ := baseOrdererOfType(t, ordererType)
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -1339,10 +1350,10 @@ func TestOrdererConfigurationFailure(t *testing.T) {
 
 			baseOrdererConfig, _ := baseOrdererOfType(t, tt.ordererType)
 			ordererGroup, err := newOrdererGroup(baseOrdererConfig)
-			if tt.ordererType != orderer.ConsensusTypeKafka {
+			if tt.ordererType != orderer.ConsensusTypeKafka && tt.ordererType != orderer.ConsensusTypeSolo {
 				gt.Expect(err).NotTo(HaveOccurred())
 			} else {
-				gt.Expect(err.Error()).To(ContainSubstring("the kafka consensus type is no longer supported"))
+				gt.Expect(err.Error()).To(ContainSubstring("consensus type is no longer supported"))
 				return
 			}
 
@@ -1372,9 +1383,14 @@ func TestSetOrdererOrg(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	orderer, _ := baseSoloOrderer(t)
-	ordererGroup, err := newOrdererGroup(orderer)
-	gt.Expect(err).NotTo(HaveOccurred())
+	orderer1, _ := baseSoloOrderer(t)
+	ordererGroup, err := newOrdererGroup(orderer1)
+	if orderer1.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -1535,9 +1551,14 @@ func TestSetOrdererOrgFailures(t *testing.T) {
 
 	gt := NewGomegaWithT(t)
 
-	orderer, _ := baseSoloOrderer(t)
-	ordererGroup, err := newOrdererGroup(orderer)
-	gt.Expect(err).NotTo(HaveOccurred())
+	orderer1, _ := baseSoloOrderer(t)
+	ordererGroup, err := newOrdererGroup(orderer1)
+	if orderer1.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -1775,8 +1796,14 @@ func TestGetOrdererOrg(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	ordererChannelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	ordererChannelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: ordererChannelGroup,
@@ -1793,7 +1820,12 @@ func TestOrdererCapabilities(t *testing.T) {
 
 	baseOrdererConf, _ := baseSoloOrderer(t)
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -1823,7 +1855,12 @@ func TestAddOrdererCapability(t *testing.T) {
 
 	baseOrdererConf, _ := baseSoloOrderer(t)
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -2462,7 +2499,13 @@ func TestAddConsenterFailures(t *testing.T) {
 			ord := tt.orderer(baseOrdererConf)
 
 			ordererGroup, err := newOrdererGroup(ord)
-			gt.Expect(err).NotTo(HaveOccurred())
+			if ord.OrdererType != orderer.ConsensusTypeSolo {
+				gt.Expect(err).NotTo(HaveOccurred())
+			} else {
+				gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+				return
+			}
+
 			tt.ordererGroup(ordererGroup, ord)
 
 			etcdRaftCert := baseOrdererConf.EtcdRaft.Consenters[0].ClientTLSCert
@@ -2836,7 +2879,12 @@ func TestRemoveConsenterFailures(t *testing.T) {
 			ord := tt.orderer(baseOrdererConf)
 
 			ordererGroup, err := newOrdererGroup(ord)
-			gt.Expect(err).NotTo(HaveOccurred())
+			if ord.OrdererType != orderer.ConsensusTypeSolo {
+				gt.Expect(err).NotTo(HaveOccurred())
+			} else {
+				gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+				return
+			}
 			tt.ordererGroup(ordererGroup, ord)
 
 			etcdRaftCert := baseOrdererConf.EtcdRaft.Consenters[0].ClientTLSCert
@@ -2898,7 +2946,12 @@ func TestAddOrdererCapabilityFailures(t *testing.T) {
 
 			baseOrdererConf, _ := baseSoloOrderer(t)
 			ordererGroup, err := newOrdererGroup(baseOrdererConf)
-			gt.Expect(err).NotTo(HaveOccurred())
+			if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+				gt.Expect(err).NotTo(HaveOccurred())
+			} else {
+				gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+				return
+			}
 			tt.ordererGroup(ordererGroup)
 
 			config := &cb.Config{
@@ -2924,7 +2977,12 @@ func TestRemoveOrdererCapability(t *testing.T) {
 
 	baseOrdererConf, _ := baseSoloOrderer(t)
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3202,7 +3260,12 @@ func TestRemoveOrdererCapabilityFailures(t *testing.T) {
 
 			baseOrdererConf, _ := baseSoloOrderer(t)
 			ordererGroup, err := newOrdererGroup(baseOrdererConf)
-			gt.Expect(err).NotTo(HaveOccurred())
+			if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+				gt.Expect(err).NotTo(HaveOccurred())
+			} else {
+				gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+				return
+			}
 			tt.ordererGroup(ordererGroup)
 
 			config := &cb.Config{
@@ -3227,7 +3290,12 @@ func TestOrdererOrg(t *testing.T) {
 
 	channel, _, _ := baseSystemChannelProfile(t)
 	channelGroup, err := newSystemChannelGroup(channel)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if channel.Orderer.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -3273,7 +3341,12 @@ func TestRemoveOrdererOrg(t *testing.T) {
 
 	channel, _, _ := baseSystemChannelProfile(t)
 	channelGroup, err := newSystemChannelGroup(channel)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if channel.Orderer.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -3292,7 +3365,12 @@ func TestSetOrdererModPolicy(t *testing.T) {
 
 	baseOrdererConf, _ := baseSoloOrderer(t)
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3318,7 +3396,12 @@ func TestSetOrdererModPolicyFailures(t *testing.T) {
 
 	baseOrdererConf, _ := baseSoloOrderer(t)
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3342,7 +3425,12 @@ func TestSetOrdererPolicy(t *testing.T) {
 	baseOrdererConf, _ := baseSoloOrderer(t)
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3398,7 +3486,12 @@ func TestSetOrdererPolicyFailures(t *testing.T) {
 	baseOrdererConf, _ := baseSoloOrderer(t)
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3423,7 +3516,12 @@ func TestSetOrdererPolicies(t *testing.T) {
 	baseOrdererConf.Policies["TestPolicy_Remove"] = baseOrdererConf.Policies[ReadersPolicyKey]
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3487,7 +3585,12 @@ func TestSetOrdererPoliciesFailures(t *testing.T) {
 	baseOrdererConf, _ := baseSoloOrderer(t)
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3531,7 +3634,12 @@ func TestSetOrdererPoliciesWithoutBlockValidationPolicyFailures(t *testing.T) {
 	baseOrdererConf, _ := baseSoloOrderer(t)
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3571,7 +3679,12 @@ func TestRemoveOrdererPolicy(t *testing.T) {
 	baseOrdererConf.Policies["TestPolicy"] = baseOrdererConf.Policies[AdminsPolicyKey]
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3623,7 +3736,12 @@ func TestRemoveOrdererPolicyFailures(t *testing.T) {
 	baseOrdererConf.Policies["TestPolicy"] = baseOrdererConf.Policies[AdminsPolicyKey]
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3676,7 +3794,12 @@ func TestSetOrdererOrgModPolicy(t *testing.T) {
 
 	baseOrdererConf, _ := baseSoloOrderer(t)
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3703,7 +3826,12 @@ func TestSetOrdererOrgModPolicyFailures(t *testing.T) {
 
 	baseOrdererConf, _ := baseSoloOrderer(t)
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3727,7 +3855,12 @@ func TestSetOrdererOrgPolicy(t *testing.T) {
 	baseOrdererConf, _ := baseSoloOrderer(t)
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3784,7 +3917,12 @@ func TestSetOrdererOrgPolicyFailures(t *testing.T) {
 	baseOrdererConf, _ := baseSoloOrderer(t)
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3809,7 +3947,12 @@ func TestSetOrdererOrgPolicies(t *testing.T) {
 	baseOrdererConf.Organizations[0].Policies["TestPolicy_Remove"] = baseOrdererConf.Organizations[0].Policies[ReadersPolicyKey]
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3874,7 +4017,12 @@ func TestSetOrdererOrgPoliciesFailures(t *testing.T) {
 	baseOrdererConf, _ := baseSoloOrderer(t)
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3919,7 +4067,12 @@ func TestRemoveOrdererOrgPolicy(t *testing.T) {
 	baseOrdererConf.Organizations[0].Policies["TestPolicy"] = baseOrdererConf.Organizations[0].Policies[AdminsPolicyKey]
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3971,7 +4124,12 @@ func TestOrdererMSP(t *testing.T) {
 	expectedMSP := soloOrderer.Organizations[0].MSP
 
 	ordererGroup, err := newOrdererGroup(soloOrderer)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if soloOrderer.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: &cb.ConfigGroup{
@@ -3992,8 +4150,14 @@ func TestUpdateOrdererMSP(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
-	channelGroup, privKeys, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-	gt.Expect(err).NotTo(HaveOccurred())
+	ordererType := orderer.ConsensusTypeSolo
+	channelGroup, privKeys, err := baseOrdererChannelGroup(t, ordererType)
+	if ordererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	config := &cb.Config{
 		ChannelGroup: channelGroup,
@@ -4306,8 +4470,14 @@ func TestUpdateOrdererMSPFailure(t *testing.T) {
 			t.Parallel()
 			gt := NewGomegaWithT(t)
 
-			channelGroup, _, err := baseOrdererChannelGroup(t, orderer.ConsensusTypeSolo)
-			gt.Expect(err).NotTo(HaveOccurred())
+			ordererType := orderer.ConsensusTypeSolo
+			channelGroup, _, err := baseOrdererChannelGroup(t, ordererType)
+			if ordererType != orderer.ConsensusTypeSolo {
+				gt.Expect(err).NotTo(HaveOccurred())
+			} else {
+				gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+				return
+			}
 
 			config := &cb.Config{
 				ChannelGroup: channelGroup,
@@ -4671,7 +4841,12 @@ func TestSetMaxMessageCountFailures(t *testing.T) {
 	gt := NewGomegaWithT(t)
 	baseOrdererConf, _ := baseSoloOrderer(t)
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	ordererGroup.Values[orderer.BatchSizeKey] = &cb.ConfigValue{Value: []byte("{")}
 	config := &cb.Config{
@@ -4695,7 +4870,12 @@ func TestSetAbsoluteMaxBytesFailures(t *testing.T) {
 
 	baseOrdererConf, _ := baseSoloOrderer(t)
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	ordererGroup.Values[orderer.BatchSizeKey] = &cb.ConfigValue{Value: []byte("{")}
 	config := &cb.Config{
@@ -4718,7 +4898,12 @@ func TestSetPreferredMaxBytesFailures(t *testing.T) {
 
 	baseOrdererConf, _ := baseSoloOrderer(t)
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
-	gt.Expect(err).NotTo(HaveOccurred())
+	if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+		gt.Expect(err).NotTo(HaveOccurred())
+	} else {
+		gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+		return
+	}
 
 	ordererGroup.Values[orderer.BatchSizeKey] = &cb.ConfigValue{Value: []byte("{")}
 	config := &cb.Config{
@@ -5608,7 +5793,12 @@ func TestSetConsensusTypeFailures(t *testing.T) {
 
 			baseOrdererConf, _ := baseSoloOrderer(t)
 			ordererGroup, err := newOrdererGroup(baseOrdererConf)
-			gt.Expect(err).NotTo(HaveOccurred())
+			if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+				gt.Expect(err).NotTo(HaveOccurred())
+			} else {
+				gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+				return
+			}
 
 			delete(ordererGroup.Values, orderer.ConsensusTypeKey)
 			config := &cb.Config{
@@ -5920,7 +6110,12 @@ func TestSetConsensusStateFailures(t *testing.T) {
 
 			baseOrdererConf, _ := baseSoloOrderer(t)
 			ordererGroup, err := newOrdererGroup(baseOrdererConf)
-			gt.Expect(err).NotTo(HaveOccurred())
+			if baseOrdererConf.OrdererType != orderer.ConsensusTypeSolo {
+				gt.Expect(err).NotTo(HaveOccurred())
+			} else {
+				gt.Expect(err.Error()).To(ContainSubstring("the solo consensus type is no longer supported"))
+				return
+			}
 
 			delete(ordererGroup.Values, orderer.ConsensusTypeKey)
 			config := &cb.Config{
@@ -6238,6 +6433,7 @@ func baseOrdererOfType(t *testing.T, ordererType string) (Orderer, []*ecdsa.Priv
 	}
 }
 
+// Deprecated: the solo consensus type is no longer supported
 func baseSoloOrderer(t *testing.T) (Orderer, []*ecdsa.PrivateKey) {
 	baseMSP, privKey := baseMSP(t)
 	return Orderer{


### PR DESCRIPTION
#### Type of change

- Test update

#### Description

This PR aims to remove solo as a consensus type. 
Tests were fixed accordingly.

#### Related issues

Issue #4496 in fabric repo.